### PR TITLE
Enhance filters and aggregates with UUID support and linked grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ CHANGES
 V 0.4.6
 --------
 
+- Added adjacent `Group By` linking controls so aggregate builders can chain
+  neighboring dimensions into a composite rollup/grouping block without manual
+  query editing.
+- Updated aggregate rollup processing to collapse linked `Group By` fields into
+  composite grouping elements, so linked dimensions execute as one grouped
+  block instead of independent rollup steps.
+- Updated aggregate table rendering so linked group blocks display as a single
+  header/value pair such as `State / Title / Rank`, and clicking the combined
+  row applies the full linked drill-down filter set.
 - Fixed UUID-aware filter and aggregate flows so filter widgets, aggregate
   processors, and related schema helpers correctly preserve and coerce UUID
   values across apply/restore paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ CHANGES
 V 0.4.6
 --------
 
+- Added CTE-backed fields directly to the normal view-column pickers with a
+  dedicated `CTE` badge, so users can discover and select overlay CTE columns
+  without a separate CTE-management control.
+- Automatically derive, persist, and re-apply required CTEs when CTE-backed
+  fields are selected, reordered, submitted, or restored from saved views, so
+  CTE-backed project views load and round-trip cleanly.
 - Added adjacent `Group By` linking controls so aggregate builders can chain
   neighboring dimensions into a composite rollup/grouping block without manual
   query editing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 CHANGES
 =======
 
+V 0.4.6
+--------
+
+- Fixed UUID-aware filter and aggregate flows so filter widgets, aggregate
+  processors, and related schema helpers correctly preserve and coerce UUID
+  values across apply/restore paths.
+- Fixed exports with duplicate column headers so dataset/export output remains
+  stable when selected fields or aliases collide.
+- Fixed aggregate drill-down filter promotion so promoted filters and related
+  aggregate interactions preserve the expected filter state.
+- Fixed custom datetime bucket SQL so relative date buckets such as
+  `today, yesterday, 2-7, 8+` compile into valid date comparisons instead of
+  invalid timestamp-vs-integer SQL.
+- Bump package version to `0.4.6`.
+
 V 0.4.5
 ----------
 

--- a/lib/selecto_components/components/list_picker.ex
+++ b/lib/selecto_components/components/list_picker.ex
@@ -19,6 +19,7 @@ defmodule SelectoComponents.Components.ListPicker do
 
   slot(:item_form)
   slot(:item_summary)
+  slot(:between_item)
 
   def render(assigns) do
     {view_id, _, _, _} = assigns.view
@@ -163,64 +164,77 @@ defmodule SelectoComponents.Components.ListPicker do
 
           <div
             :for={{{id, item, conf}, index} <- Enum.with_index(@selected_items)}
-            id={"#{@component_dom_id}-item-#{id}"}
-            phx-hook=".ListPickerEditor"
-            draggable="true"
-            data-picker-item-id={id}
-            class="w-full rounded-xl border px-3 py-2 shadow-sm transition"
-            style="border-color: var(--sc-surface-border); background: color-mix(in srgb, var(--sc-surface-bg-alt) 65%, var(--sc-surface-bg)); color: var(--sc-text-primary);"
+            id={"#{@component_dom_id}-selection-#{id}"}
+            class="space-y-2"
           >
-            <% selected_type = selected_item_type(@available, item) %>
-            <div class="flex items-center gap-3">
-              <button
-                type="button"
-                class="cursor-grab active:cursor-grabbing"
-                style="color: var(--sc-text-muted);"
-                title="Drag to reorder"
-              >
-                <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path d="M7 4a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm0 6a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm-1.5 7.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm10-13.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm-1.5 7.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm1.5 6a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
-                </svg>
-              </button>
+            <div
+              id={"#{@component_dom_id}-item-#{id}"}
+              phx-hook=".ListPickerEditor"
+              draggable="true"
+              data-picker-item-id={id}
+              class="w-full rounded-xl border px-3 py-2 shadow-sm transition"
+              style="border-color: var(--sc-surface-border); background: color-mix(in srgb, var(--sc-surface-bg-alt) 65%, var(--sc-surface-bg)); color: var(--sc-text-primary);"
+            >
+              <% selected_type = selected_item_type(@available, item) %>
+              <div class="flex items-center gap-3">
+                <button
+                  type="button"
+                  class="cursor-grab active:cursor-grabbing"
+                  style="color: var(--sc-text-muted);"
+                  title="Drag to reorder"
+                >
+                  <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M7 4a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm0 6a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm-1.5 7.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm10-13.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Zm-1.5 7.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm1.5 6a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+                  </svg>
+                </button>
 
-              <div class="min-w-0 flex-1">
-                <div class="flex min-w-0 items-center gap-2 text-sm">
-                  <.type_badge type={selected_type} />
-                  <div class="min-w-0 flex-1 truncate font-medium">
-                    <%= if @item_summary != [] do %>
-                      {render_slot(@item_summary, {id, item, conf, index})}
-                    <% else %>
-                      <span class="truncate">{item}</span>
-                    <% end %>
+                <div class="min-w-0 flex-1">
+                  <div class="flex min-w-0 items-center gap-2 text-sm">
+                    <.type_badge type={selected_type} />
+                    <div class="min-w-0 flex-1 truncate font-medium">
+                      <%= if @item_summary != [] do %>
+                        {render_slot(@item_summary, {id, item, conf, index})}
+                      <% else %>
+                        <span class="truncate">{item}</span>
+                      <% end %>
+                    </div>
                   </div>
+                </div>
+
+                <div class="flex shrink-0 items-center gap-1.5">
+                  <button
+                    type="button"
+                    data-editor-toggle
+                    class={[Theme.slot(@theme, :button_secondary), "h-7", "px-2", "text-xs"]}
+                  >
+                    <span data-editor-open-label>Edit</span>
+                    <span data-editor-close-label class="hidden">Close</span>
+                  </button>
+                  <.sc_x_button
+                    theme={@theme}
+                    data-picker-action="remove"
+                    data-view-id={@view_id}
+                    data-list-id={@fieldname}
+                    data-item-id={id}
+                  />
                 </div>
               </div>
 
-              <div class="flex shrink-0 items-center gap-1.5">
-                <button
-                  type="button"
-                  data-editor-toggle
-                  class={[Theme.slot(@theme, :button_secondary), "h-7", "px-2", "text-xs"]}
-                >
-                  <span data-editor-open-label>Edit</span>
-                  <span data-editor-close-label class="hidden">Close</span>
-                </button>
-                <.sc_x_button
-                  theme={@theme}
-                  data-picker-action="remove"
-                  data-view-id={@view_id}
-                  data-list-id={@fieldname}
-                  data-item-id={id}
-                />
+              <div
+                data-editor-content
+                class="mt-3 hidden border-t pt-3"
+                style="border-color: var(--sc-surface-border);"
+              >
+                {render_slot(@item_form, {id, item, conf, index})}
               </div>
             </div>
 
             <div
-              data-editor-content
-              class="mt-3 hidden border-t pt-3"
-              style="border-color: var(--sc-surface-border);"
+              :if={@between_item != [] and index < length(@selected_items) - 1}
+              id={"#{@component_dom_id}-between-#{id}-#{elem(Enum.at(@selected_items, index + 1), 0)}"}
+              class="flex justify-center"
             >
-              {render_slot(@item_form, {id, item, conf, index})}
+              {render_slot(@between_item, {id, item, conf, index, Enum.at(@selected_items, index + 1)})}
             </div>
           </div>
         </div>

--- a/lib/selecto_components/components/list_picker.ex
+++ b/lib/selecto_components/components/list_picker.ex
@@ -787,6 +787,10 @@ defmodule SelectoComponents.Components.ListPicker do
           <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M4.75 3a1.75 1.75 0 1 0 0 3.5A1.75 1.75 0 0 0 4.75 3ZM13.5 5.5a1.5 1.5 0 0 1 1.5 1.5v1.2a2.3 2.3 0 0 0-.7-.1H9.44a2.75 2.75 0 0 0-2.44-1.5H6.3a2.74 2.74 0 0 0-.31-1.2H13.5ZM15.25 13.5a1.75 1.75 0 1 0 0 3.5 1.75 1.75 0 0 0 0-3.5ZM5 9.1A1.5 1.5 0 0 1 6.5 7.6h.5A1.5 1.5 0 0 1 8.5 9.1v.4h5.8A1.7 1.7 0 0 1 16 11.2v1.1a2.74 2.74 0 0 0-1.2-.3h-.46A2.75 2.75 0 0 0 11.7 10H8.4A2.4 2.4 0 0 1 6 12.4H5V9.1Z" />
           </svg>
+        <% :cte -> %>
+          <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M4.75 4A1.75 1.75 0 1 0 4.75 7.5 1.75 1.75 0 0 0 4.75 4ZM4.75 12.5A1.75 1.75 0 1 0 4.75 16a1.75 1.75 0 0 0 0-3.5ZM8 5a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5A.75.75 0 0 1 8 5Zm0 8.5a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5A.75.75 0 0 1 8 13.5Zm-.25-3.5A1.75 1.75 0 0 1 9.5 8.25h1v-1a.75.75 0 0 1 1.5 0v1h1A1.75 1.75 0 0 1 14.75 10v.5a.75.75 0 0 1-1.5 0V10a.25.25 0 0 0-.25-.25h-1v1a.75.75 0 0 1-1.5 0v-1h-1a.25.25 0 0 0-.25.25v.5a.75.75 0 0 1-1.5 0V10Z" />
+          </svg>
         <% :list -> %>
           <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M5 4.75A1.25 1.25 0 1 1 2.5 4.75 1.25 1.25 0 0 1 5 4.75ZM6.75 4a.75.75 0 0 0 0 1.5H16a.75.75 0 0 0 0-1.5H6.75ZM5 10a1.25 1.25 0 1 1-2.5 0A1.25 1.25 0 0 1 5 10Zm1.75-.75a.75.75 0 0 0 0 1.5H16a.75.75 0 0 0 0-1.5H6.75ZM5 15.25a1.25 1.25 0 1 1-2.5 0 1.25 1.25 0 0 1 2.5 0ZM6.75 14.5a.75.75 0 0 0 0 1.5H16a.75.75 0 0 0 0-1.5H6.75Z" />
@@ -826,6 +830,7 @@ defmodule SelectoComponents.Components.ListPicker do
       :boolean -> "Boolean"
       :text -> "Text"
       :relation -> "Relation"
+      :cte -> "CTE"
       :list -> "List"
       :json -> "JSON"
       :uuid -> "UUID"
@@ -860,6 +865,9 @@ defmodule SelectoComponents.Components.ListPicker do
 
       :relation ->
         "color: color-mix(in srgb, var(--sc-text-primary) 84%, #b16b80); opacity: 0.82;"
+
+      :cte ->
+        "color: color-mix(in srgb, var(--sc-text-primary) 84%, #2d7c88); opacity: 0.9;"
 
       :list ->
         "color: color-mix(in srgb, var(--sc-text-primary) 84%, #6b89b5); opacity: 0.82;"

--- a/lib/selecto_components/denormalization_detector.ex
+++ b/lib/selecto_components/denormalization_detector.ex
@@ -253,15 +253,19 @@ defmodule SelectoComponents.DenormalizationDetector do
   end
 
   defp one_to_many_join?(selecto, join_segment, join_config) do
+    if Map.get(join_config, :source_kind) == :cte do
+      false
+    else
     target_primary_key = find_target_primary_key(selecto, join_segment, join_config)
     join_target_key = Map.get(join_config, :my_key)
 
-    cond do
-      not is_nil(target_primary_key) and not is_nil(join_target_key) ->
-        normalize_join_key(join_target_key) != normalize_join_key(target_primary_key)
+      cond do
+        not is_nil(target_primary_key) and not is_nil(join_target_key) ->
+          normalize_join_key(join_target_key) != normalize_join_key(target_primary_key)
 
-      true ->
-        relationship_type_from_name(join_segment) == :one_to_many
+        true ->
+          relationship_type_from_name(join_segment) == :one_to_many
+      end
     end
   end
 

--- a/lib/selecto_components/denormalization_detector.ex
+++ b/lib/selecto_components/denormalization_detector.ex
@@ -256,8 +256,8 @@ defmodule SelectoComponents.DenormalizationDetector do
     if Map.get(join_config, :source_kind) == :cte do
       false
     else
-    target_primary_key = find_target_primary_key(selecto, join_segment, join_config)
-    join_target_key = Map.get(join_config, :my_key)
+      target_primary_key = find_target_primary_key(selecto, join_segment, join_config)
+      join_target_key = Map.get(join_config, :my_key)
 
       cond do
         not is_nil(target_primary_key) and not is_nil(join_target_key) ->

--- a/lib/selecto_components/exporter.ex
+++ b/lib/selecto_components/exporter.ex
@@ -42,7 +42,7 @@ defmodule SelectoComponents.Exporter do
       view_mode: view_mode,
       row_count: length(dataset.rows),
       columns: dataset.headers,
-      rows: dataset.rows
+      rows: json_rows(dataset)
     }
 
     {:ok,
@@ -95,8 +95,7 @@ defmodule SelectoComponents.Exporter do
 
     data_rows =
       Enum.map(dataset.rows, fn row_map ->
-        dataset.headers
-        |> Enum.map(fn header -> Map.get(row_map, header) end)
+        row_values(dataset, row_map)
         |> Enum.map_join(delimiter, fn value ->
           value
           |> Dataset.value_to_string()
@@ -160,7 +159,7 @@ defmodule SelectoComponents.Exporter do
 
   defp worksheet_xml(dataset) do
     rows =
-      [dataset.headers | Enum.map(dataset.rows, &row_values(dataset.headers, &1))]
+      [dataset.headers | Enum.map(dataset.rows, &row_values(dataset, &1))]
       |> Enum.with_index(1)
       |> Enum.map_join("", fn {row, row_index} ->
         "<row r=\"#{row_index}\">#{cells_xml(row, row_index)}</row>"
@@ -198,8 +197,30 @@ defmodule SelectoComponents.Exporter do
     "<c r=\"#{ref}\" t=\"inlineStr\"><is><t xml:space=\"preserve\">#{escaped}</t></is></c>"
   end
 
-  defp row_values(headers, row_map) do
-    Enum.map(headers, &Map.get(row_map, &1))
+  defp row_values(dataset, row_map) do
+    keys = Map.get(dataset, :row_keys, dataset.headers)
+    Enum.map(keys, &Map.get(row_map, &1))
+  end
+
+  defp json_rows(dataset) do
+    headers = unique_json_headers(dataset.headers)
+
+    Enum.map(dataset.rows, fn row_map ->
+      headers
+      |> Enum.zip(row_values(dataset, row_map))
+      |> Map.new()
+    end)
+  end
+
+  defp unique_json_headers(headers) do
+    {unique_headers, _counts} =
+      Enum.map_reduce(headers, %{}, fn header, counts ->
+        count = Map.get(counts, header, 0) + 1
+        unique_header = if count == 1, do: header, else: "#{header} (#{count})"
+        {unique_header, Map.put(counts, header, count)}
+      end)
+
+    unique_headers
   end
 
   defp cell_ref(col_index, row_index) do

--- a/lib/selecto_components/exporter/dataset.ex
+++ b/lib/selecto_components/exporter/dataset.ex
@@ -4,6 +4,7 @@ defmodule SelectoComponents.Exporter.Dataset do
   @type t :: %{
           kind: :table | :grid,
           headers: [String.t()],
+          row_keys: [String.t()],
           rows: [map()],
           metadata: map()
         }
@@ -69,16 +70,18 @@ defmodule SelectoComponents.Exporter.Dataset do
 
   defp build_table_dataset({rows, columns, _aliases}) do
     headers = headers(columns, rows)
+    row_keys = Enum.map(0..max(length(headers) - 1, 0), &"__col_#{&1}")
 
     normalized_rows =
       Enum.map(rows, fn row ->
-        normalize_row(row, columns, headers)
+        normalize_row(row, columns, headers, row_keys)
       end)
 
     {:ok,
      %{
        kind: :table,
        headers: headers,
+       row_keys: row_keys,
        rows: normalized_rows,
        metadata: %{row_count: length(normalized_rows)}
      }}
@@ -104,6 +107,7 @@ defmodule SelectoComponents.Exporter.Dataset do
      %{
        kind: :grid,
        headers: headers,
+       row_keys: headers,
        rows: normalized_rows,
        metadata: %{row_count: length(normalized_rows), row_header: row_header}
      }}
@@ -281,42 +285,48 @@ defmodule SelectoComponents.Exporter.Dataset do
     end
   end
 
-  defp normalize_row(row, columns, headers) when is_map(row) do
-    Enum.reduce(headers, %{}, fn header, acc ->
-      value = fetch_map_value_for_header(row, header, columns)
-      Map.put(acc, header, sanitize_value(value))
+  defp normalize_row(row, columns, headers, row_keys) when is_map(row) do
+    headers
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn {header, idx}, acc ->
+      value = fetch_map_value_for_header(row, header, columns, idx)
+      Map.put(acc, Enum.at(row_keys, idx), sanitize_value(value))
     end)
   end
 
-  defp normalize_row(row, _columns, headers) when is_tuple(row) do
+  defp normalize_row(row, _columns, _headers, row_keys) when is_tuple(row) do
     row
     |> Tuple.to_list()
-    |> normalize_row_from_list(headers)
+    |> normalize_row_from_list(row_keys)
   end
 
-  defp normalize_row(row, _columns, headers) when is_list(row) do
-    normalize_row_from_list(row, headers)
+  defp normalize_row(row, _columns, _headers, row_keys) when is_list(row) do
+    normalize_row_from_list(row, row_keys)
   end
 
-  defp normalize_row(value, _columns, []) do
+  defp normalize_row(value, _columns, _headers, []) do
     %{"value" => sanitize_value(value)}
   end
 
-  defp normalize_row(value, _columns, headers) do
-    header = List.first(headers)
-    Map.new(headers, fn h -> {h, if(h == header, do: sanitize_value(value), else: nil)} end)
+  defp normalize_row(value, _columns, _headers, row_keys) do
+    row_key = List.first(row_keys)
+
+    Map.new(row_keys, fn key ->
+      {key, if(key == row_key, do: sanitize_value(value), else: nil)}
+    end)
   end
 
-  defp normalize_row_from_list(list_row, headers) do
-    headers
+  defp normalize_row_from_list(list_row, row_keys) do
+    row_keys
     |> Enum.zip(list_row)
     |> Enum.into(%{}, fn {header, value} ->
       {header, sanitize_value(value)}
     end)
   end
 
-  defp fetch_map_value_for_header(row, header, columns) do
-    column_reference = Enum.find(columns, fn column -> to_string(column) == header end)
+  defp fetch_map_value_for_header(row, header, columns, idx) do
+    column_reference =
+      Enum.at(columns, idx) || Enum.find(columns, fn column -> to_string(column) == header end)
 
     atom_key =
       cond do

--- a/lib/selecto_components/filter/multi_select_filter.ex
+++ b/lib/selecto_components/filter/multi_select_filter.ex
@@ -139,26 +139,19 @@ defmodule SelectoComponents.Filter.MultiSelectFilter do
 
   @impl true
   def handle_event("toggle", %{"id" => id_str}, socket) do
-    case Integer.parse(id_str) do
-      {id, ""} ->
-        selected_ids = socket.assigns.selected_ids
+    selected_ids = socket.assigns.selected_ids
 
-        selected_ids =
-          if id in selected_ids do
-            List.delete(selected_ids, id)
-          else
-            [id | selected_ids]
-          end
+    selected_ids =
+      if id_str in selected_ids do
+        List.delete(selected_ids, id_str)
+      else
+        [id_str | selected_ids]
+      end
 
-        # Update parent component with new value (comma-separated IDs)
-        value = Enum.join(selected_ids, ",")
-        send(self(), {:multi_select_changed, socket.assigns.filter_id, value})
+    value = Enum.join(selected_ids, ",")
+    send(self(), {:multi_select_changed, socket.assigns.filter_id, value})
 
-        {:noreply, assign(socket, selected_ids: selected_ids)}
-
-      _ ->
-        {:noreply, socket}
-    end
+    {:noreply, assign(socket, selected_ids: selected_ids)}
   end
 
   @impl true
@@ -247,7 +240,7 @@ defmodule SelectoComponents.Filter.MultiSelectFilter do
       case execute_options_query(connection, query, [limit]) do
         {:ok, %{rows: rows}} ->
           Enum.map(rows, fn [id, name] ->
-            %{id: id, name: to_string(name)}
+            %{id: normalize_option_id(id), name: to_string(name)}
           end)
 
         {:error, error} ->
@@ -309,14 +302,17 @@ defmodule SelectoComponents.Filter.MultiSelectFilter do
     |> String.split(",")
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
-    |> Enum.map(fn id_str ->
-      case Integer.parse(id_str) do
-        {id, _} -> id
-        :error -> nil
-      end
-    end)
-    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&normalize_option_id/1)
   end
 
   defp parse_ids(_), do: []
+
+  defp normalize_option_id(id) when is_binary(id) do
+    case Ecto.UUID.load(id) do
+      {:ok, uuid} -> uuid
+      :error -> id
+    end
+  end
+
+  defp normalize_option_id(id), do: to_string(id)
 end

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -1094,17 +1094,19 @@ defmodule SelectoComponents.Form do
   ### __using___
 
   defp build_column_list(selecto) do
-    Map.values(Selecto.columns(selecto))
-    |> Enum.sort(fn a, b -> a.name <= b.name end)
-    |> Enum.map(fn c ->
-      {c.colid, c.name,
+    Selecto.columns(selecto)
+    |> Enum.map(fn {colid, column} ->
+      column = Map.put_new(column, :colid, colid)
+
+      {column.colid, column.name,
        %{
-         type: Selecto.Temporal.date_like_type(c) || Map.get(c, :type),
-         format: Map.get(c, :format),
-         icon: Map.get(c, :icon),
-         icon_family: Map.get(c, :icon_family)
+         type: Selecto.Temporal.date_like_type(column) || Map.get(column, :type),
+         format: Map.get(column, :format),
+         icon: Map.get(column, :icon),
+         icon_family: Map.get(column, :icon_family)
        }}
     end)
+    |> Enum.sort(fn {_, left_name, _}, {_, right_name, _} -> left_name <= right_name end)
   end
 
   # defp build_available_fields(selecto) do

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -5,6 +5,7 @@ defmodule SelectoComponents.Form do
   alias SelectoComponents.ErrorHandling.ErrorBuilder
   alias SelectoComponents.ErrorHandling.ErrorSanitizer
   alias SelectoComponents.ErrorHandling.ErrorDisplay
+  alias SelectoComponents.Form.ColumnCatalog
   alias SelectoComponents.Form.ExportPanel
   alias SelectoComponents.Form.FilterPanel
   alias SelectoComponents.Form.FilterRendering
@@ -28,12 +29,15 @@ defmodule SelectoComponents.Form do
 
   @impl true
   def render(assigns) do
+    form_selecto = ColumnCatalog.picker_selecto(assigns.selecto)
+
     controller_filters =
       controller_filters(assigns.selecto, Map.get(assigns.view_config, :filters, []))
 
     assigns =
       assign(assigns,
         columns: build_column_list(assigns.selecto),
+        form_selecto: form_selecto,
         field_filters: FilterRendering.build_filter_list(assigns.selecto),
         controller_title: Map.get(assigns, :controller_title, "View Controller"),
         show_view_configurator: Map.get(assigns, :show_view_configurator, true),
@@ -193,7 +197,7 @@ defmodule SelectoComponents.Form do
             parent_id={@myself}
             views={@views}
             columns={@columns}
-            selecto={@selecto}
+            selecto={@form_selecto}
           />
 
           <FilterPanel.panel
@@ -733,14 +737,19 @@ defmodule SelectoComponents.Form do
       filter_def || column_def || controller_filter_field_type(selecto, filter)
   end
 
-  defp controller_join_mode_field_conf(_selecto, _filter_id, %{
-         join_mode: join_mode,
-         filter_type: :multi_select_id
-       } = current_def)
+  defp controller_join_mode_field_conf(
+         _selecto,
+         _filter_id,
+         %{
+           join_mode: join_mode,
+           filter_type: :multi_select_id
+         } = current_def
+       )
        when join_mode in [:lookup, :star, :tag],
        do: current_def
 
-  defp controller_join_mode_field_conf(selecto, filter_id, current_def) when is_binary(filter_id) do
+  defp controller_join_mode_field_conf(selecto, filter_id, current_def)
+       when is_binary(filter_id) do
     domain = Selecto.domain(selecto)
 
     resolved_conf =
@@ -1093,21 +1102,7 @@ defmodule SelectoComponents.Form do
 
   ### __using___
 
-  defp build_column_list(selecto) do
-    Selecto.columns(selecto)
-    |> Enum.map(fn {colid, column} ->
-      column = Map.put_new(column, :colid, colid)
-
-      {column.colid, column.name,
-       %{
-         type: Selecto.Temporal.date_like_type(column) || Map.get(column, :type),
-         format: Map.get(column, :format),
-         icon: Map.get(column, :icon),
-         icon_family: Map.get(column, :icon_family)
-       }}
-    end)
-    |> Enum.sort(fn {_, left_name, _}, {_, right_name, _} -> left_name <= right_name end)
-  end
+  defp build_column_list(selecto), do: ColumnCatalog.picker_columns(selecto)
 
   # defp build_available_fields(selecto) do
   #   Selecto.columns(selecto)

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -171,7 +171,7 @@ defmodule SelectoComponents.Form do
           show_view_configurator={@show_view_configurator}
         >
           <:promoted_filter :let={filter}>
-            <PromotedFilterEditor.editor filter={filter} theme={@theme} />
+            <PromotedFilterEditor.editor filter={filter} theme={@theme} selecto={@selecto} />
           </:promoted_filter>
         </Header.summary>
 
@@ -681,9 +681,6 @@ defmodule SelectoComponents.Form do
       controller_filter_custom_component?(selecto, filter) ->
         :unsupported
 
-      controller_filter_multi_select?(selecto, filter) ->
-        :unsupported
-
       polymorphic_filter?(filter) ->
         :unsupported
 
@@ -702,17 +699,6 @@ defmodule SelectoComponents.Form do
     case controller_filter_definition(selecto, filter) do
       %{type: :component, component: component} when not is_nil(component) -> true
       _ -> false
-    end
-  end
-
-  defp controller_filter_multi_select?(selecto, filter) do
-    case controller_filter_field_conf(selecto, filter) do
-      %{join_mode: join_mode, filter_type: :multi_select_id}
-      when join_mode in [:lookup, :star, :tag] ->
-        true
-
-      _ ->
-        false
     end
   end
 
@@ -739,10 +725,95 @@ defmodule SelectoComponents.Form do
   end
 
   defp controller_filter_field_conf(selecto, filter) do
+    filter_id = Map.get(filter, "filter") || Map.get(filter, :filter)
     filter_def = controller_filter_definition(selecto, filter)
     column_def = controller_filter_column_definition(selecto, filter, filter_def)
 
-    filter_def || column_def || controller_filter_field_type(selecto, filter)
+    controller_join_mode_field_conf(selecto, filter_id, filter_def || column_def) ||
+      filter_def || column_def || controller_filter_field_type(selecto, filter)
+  end
+
+  defp controller_join_mode_field_conf(_selecto, _filter_id, %{
+         join_mode: join_mode,
+         filter_type: :multi_select_id
+       } = current_def)
+       when join_mode in [:lookup, :star, :tag],
+       do: current_def
+
+  defp controller_join_mode_field_conf(selecto, filter_id, current_def) when is_binary(filter_id) do
+    domain = Selecto.domain(selecto)
+
+    resolved_conf =
+      cond do
+        String.contains?(filter_id, ".") ->
+          [schema_name, field_part] = String.split(filter_id, ".", parts: 2)
+
+          if field_part == "id" or String.ends_with?(field_part, "_id") do
+            controller_join_mode_conf_from_id_field(domain, schema_name, field_part)
+          end
+
+        String.ends_with?(filter_id, "_id") ->
+          controller_join_mode_conf_from_group_by_filter(domain, filter_id)
+
+        true ->
+          nil
+      end
+
+    case resolved_conf do
+      %{} = join_mode_conf -> Map.merge(current_def || %{}, join_mode_conf)
+      _ -> nil
+    end
+  end
+
+  defp controller_join_mode_field_conf(_selecto, _filter_id, _current_def), do: nil
+
+  defp controller_join_mode_conf_from_id_field(domain, schema_name, field_part) do
+    schema_atom =
+      try do
+        String.to_existing_atom(schema_name)
+      rescue
+        ArgumentError -> nil
+      end
+
+    if schema_atom do
+      domain
+      |> get_in([:schemas, schema_atom, :columns])
+      |> case do
+        columns when is_map(columns) ->
+          Enum.find_value(columns, fn {_col_name, col_config} ->
+            join_mode = Map.get(col_config, :join_mode)
+            id_field = Map.get(col_config, :id_field)
+            filter_type = Map.get(col_config, :filter_type)
+
+            if join_mode in [:lookup, :star, :tag] and filter_type == :multi_select_id and
+                 (id_field == :id or Atom.to_string(id_field) == field_part) do
+              col_config
+            end
+          end)
+
+        _ ->
+          nil
+      end
+    end
+  end
+
+  defp controller_join_mode_conf_from_group_by_filter(domain, filter_id) do
+    domain
+    |> Map.get(:schemas, %{})
+    |> Enum.find_value(fn {_schema_name, schema_config} ->
+      schema_config
+      |> Map.get(:columns, %{})
+      |> Enum.find_value(fn {_col_name, col_config} ->
+        join_mode = Map.get(col_config, :join_mode)
+        filter_type = Map.get(col_config, :filter_type)
+        group_by_filter = Map.get(col_config, :group_by_filter)
+
+        if join_mode in [:lookup, :star, :tag] and filter_type == :multi_select_id and
+             group_by_filter == filter_id do
+          col_config
+        end
+      end)
+    end)
   end
 
   defp controller_filter_definition(selecto, filter) do

--- a/lib/selecto_components/form/column_catalog.ex
+++ b/lib/selecto_components/form/column_catalog.ex
@@ -1,0 +1,102 @@
+defmodule SelectoComponents.Form.ColumnCatalog do
+  @moduledoc false
+
+  def picker_selecto(%Selecto{} = selecto) do
+    selecto
+    |> base_selecto()
+    |> then(fn base_selecto ->
+      Enum.reduce(available_cte_names(selecto), base_selecto, fn name, acc ->
+        Selecto.with_cte(acc, name)
+      end)
+    end)
+  rescue
+    _ -> selecto
+  end
+
+  def picker_selecto(selecto), do: selecto
+
+  def picker_columns(%Selecto{} = selecto) do
+    cte_names = available_cte_names(selecto)
+
+    selecto
+    |> picker_selecto()
+    |> Selecto.columns()
+    |> Enum.map(fn {colid, column} ->
+      column = Map.put_new(column, :colid, colid)
+
+      {column.colid, column.name,
+       %{
+         type: Selecto.Temporal.date_like_type(column) || Map.get(column, :type),
+         format: Map.get(column, :format),
+         icon: picker_icon(column, cte_names),
+         icon_family: picker_icon(column, cte_names),
+         cte_name: cte_name_for_field_id(column.colid, cte_names)
+       }}
+    end)
+    |> Enum.sort(fn {_, left_name, _}, {_, right_name, _} -> left_name <= right_name end)
+  end
+
+  def picker_columns(_), do: []
+
+  def available_cte_names(%Selecto{} = selecto) do
+    selecto
+    |> Selecto.domain()
+    |> Map.get(:query_members, %{})
+    |> Map.get(:ctes, %{})
+    |> Map.keys()
+    |> Enum.map(&to_string/1)
+  end
+
+  def available_cte_names(_), do: []
+
+  def required_cte_names_for_fields(%Selecto{} = selecto, field_ids) when is_list(field_ids) do
+    cte_names = available_cte_names(selecto)
+
+    Enum.reduce(field_ids, [], fn field_id, acc ->
+      case cte_name_for_field_id(field_id, cte_names) do
+        nil ->
+          acc
+
+        cte_name ->
+          if cte_name in acc, do: acc, else: acc ++ [cte_name]
+      end
+    end)
+  end
+
+  def required_cte_names_for_fields(_selecto, _field_ids), do: []
+
+  def cte_name_for_field_id(field_id, cte_names) when is_list(cte_names) do
+    with field_id when is_binary(field_id) <- normalize_field_id(field_id),
+         true <- String.contains?(field_id, "."),
+         [cte_name, _rest] <- String.split(field_id, ".", parts: 2),
+         true <- cte_name in cte_names do
+      cte_name
+    else
+      _ -> nil
+    end
+  end
+
+  def cte_name_for_field_id(_field_id, _cte_names), do: nil
+
+  defp base_selecto(%Selecto{} = selecto) do
+    Selecto.configure(
+      selecto.domain,
+      selecto.postgrex_opts,
+      adapter: selecto.adapter,
+      validate: false
+    )
+  end
+
+  defp picker_icon(column, cte_names) do
+    case cte_name_for_field_id(Map.get(column, :colid), cte_names) do
+      nil -> Map.get(column, :icon) || Map.get(column, :icon_family)
+      _cte_name -> :cte
+    end
+  end
+
+  defp normalize_field_id(field_id) when is_binary(field_id), do: field_id
+  defp normalize_field_id(field_id) when is_atom(field_id), do: Atom.to_string(field_id)
+  defp normalize_field_id({_func, {field_id, _format}}), do: normalize_field_id(field_id)
+  defp normalize_field_id({_func, field_id}), do: normalize_field_id(field_id)
+  defp normalize_field_id(_field_id), do: nil
+end

--- a/lib/selecto_components/form/drill_down_filters.ex
+++ b/lib/selecto_components/form/drill_down_filters.ex
@@ -382,8 +382,8 @@ defmodule SelectoComponents.Form.DrillDownFilters do
         [min_days_str, max_days_str] = String.split(value, "-")
         max_days = String.to_integer(max_days_str)
         min_days = String.to_integer(min_days_str)
-        start_date = Date.add(today, -(max_days + 1))
-        end_date = Date.add(today, -min_days)
+        start_date = Date.add(today, -max_days)
+        end_date = Date.add(today, -(min_days - 1))
         {"DATE_BETWEEN", Date.to_iso8601(start_date), Date.to_iso8601(end_date)}
 
       String.match?(value, ~r/^(\d+)\+$/) ->

--- a/lib/selecto_components/form/drill_down_filters.ex
+++ b/lib/selecto_components/form/drill_down_filters.ex
@@ -486,7 +486,9 @@ defmodule SelectoComponents.Form.DrillDownFilters do
     group_by_config = Map.get(used_params_map(socket), "group_by", %{})
     field_group_config = find_field_group_config(group_by_config, field_name, group_idx)
     drill_context = drill_context_from_group_config(field_group_config)
-    {comp_mode, v1, v2} = determine_filter_comp_and_values(value, conf, drill_context)
+    {comp_mode, v1, v2} =
+      determine_filter_comp_and_values(value, conf, drill_context)
+      |> normalize_join_mode_filter_comp(conf)
 
     actual_filter_field =
       cond do
@@ -594,6 +596,25 @@ defmodule SelectoComponents.Form.DrillDownFilters do
   end
 
   defp filter_matches_spec?(_filter, _spec), do: false
+
+  defp normalize_join_mode_filter_comp({comp_mode, v1, v2}, %{
+         join_mode: join_mode,
+         filter_type: :multi_select_id
+       })
+       when join_mode in [:lookup, :star, :tag] do
+    normalized_comp =
+      case comp_mode do
+        "=" -> "IN"
+        "!=" -> "NOT IN"
+        "IS_EMPTY" -> "IS NULL"
+        "IS_NOT_EMPTY" -> "IS NOT NULL"
+        other -> other
+      end
+
+    {normalized_comp, v1, v2}
+  end
+
+  defp normalize_join_mode_filter_comp(result, _conf), do: result
 
   defp find_join_mode_field(selecto, field_name, original_conf) do
     cond do

--- a/lib/selecto_components/form/drill_down_filters.ex
+++ b/lib/selecto_components/form/drill_down_filters.ex
@@ -79,13 +79,22 @@ defmodule SelectoComponents.Form.DrillDownFilters do
     end
   end
 
-  defp find_field_group_config(group_by_config, field_name, group_idx) do
-    by_index = find_field_group_config_by_index(group_by_config, group_idx)
+  defp find_field_group_config(used_params, field_name, group_idx) when is_map(used_params) do
+    group_by_config = Map.get(used_params, "group_by", %{})
+
+    find_field_group_config_in_collection(group_by_config, field_name, group_idx) ||
+      find_graph_group_config(used_params, field_name, group_idx)
+  end
+
+  defp find_field_group_config(_used_params, _field_name, _group_idx), do: nil
+
+  defp find_field_group_config_in_collection(config_map, field_name, group_idx) when is_map(config_map) do
+    by_index = find_field_group_config_by_index(config_map, group_idx)
 
     if by_index do
       by_index
     else
-      Enum.find_value(Map.values(group_by_config), fn config ->
+      Enum.find_value(Map.values(config_map), fn config ->
         if Map.get(config, "field") == field_name do
           config
         else
@@ -94,6 +103,8 @@ defmodule SelectoComponents.Form.DrillDownFilters do
       end)
     end
   end
+
+  defp find_field_group_config_in_collection(_config_map, _field_name, _group_idx), do: nil
 
   defp find_field_group_config_by_index(group_by_config, group_idx)
        when is_binary(group_idx) and group_idx != "" do
@@ -104,6 +115,49 @@ defmodule SelectoComponents.Form.DrillDownFilters do
   end
 
   defp find_field_group_config_by_index(_group_by_config, _group_idx), do: nil
+
+  defp find_graph_group_config(used_params, field_name, group_idx) do
+    used_params
+    |> graph_group_configs()
+    |> Enum.find(fn %{global_index: global_index, config: config} ->
+      global_index == group_idx || Map.get(config, "field") == field_name
+    end)
+    |> case do
+      nil -> nil
+      %{config: config} -> config
+    end
+  end
+
+  defp graph_group_configs(used_params) do
+    x_axis =
+      used_params
+      |> Map.get("x_axis", %{})
+      |> ordered_field_configs()
+
+    series =
+      used_params
+      |> Map.get("series", %{})
+      |> ordered_field_configs()
+
+    (x_axis ++ series)
+    |> Enum.with_index()
+    |> Enum.map(fn {config, global_index} ->
+      %{global_index: Integer.to_string(global_index), config: config}
+    end)
+  end
+
+  defp ordered_field_configs(configs) when is_map(configs) do
+    configs
+    |> Map.values()
+    |> Enum.sort_by(fn config ->
+      config
+      |> Map.get("index", "0")
+      |> to_string()
+      |> String.to_integer()
+    end)
+  end
+
+  defp ordered_field_configs(_configs), do: []
 
   @doc """
   Determine the appropriate comparison operator and values based on the clicked value format.
@@ -525,8 +579,8 @@ defmodule SelectoComponents.Form.DrillDownFilters do
       |> Selecto.field(field_name)
       |> then(&find_join_mode_field(socket.assigns.selecto, field_name, &1))
 
-    group_by_config = Map.get(used_params_map(socket), "group_by", %{})
-    field_group_config = find_field_group_config(group_by_config, field_name, group_idx)
+    used_params = used_params_map(socket)
+    field_group_config = find_field_group_config(used_params, field_name, group_idx)
     drill_context = drill_context_from_group_config(field_group_config)
     {comp_mode, v1, v2} =
       determine_filter_comp_and_values(value, conf, drill_context)

--- a/lib/selecto_components/form/drill_down_filters.ex
+++ b/lib/selecto_components/form/drill_down_filters.ex
@@ -88,7 +88,8 @@ defmodule SelectoComponents.Form.DrillDownFilters do
 
   defp find_field_group_config(_used_params, _field_name, _group_idx), do: nil
 
-  defp find_field_group_config_in_collection(config_map, field_name, group_idx) when is_map(config_map) do
+  defp find_field_group_config_in_collection(config_map, field_name, group_idx)
+       when is_map(config_map) do
     by_index = find_field_group_config_by_index(config_map, group_idx)
 
     if by_index do
@@ -582,6 +583,7 @@ defmodule SelectoComponents.Form.DrillDownFilters do
     used_params = used_params_map(socket)
     field_group_config = find_field_group_config(used_params, field_name, group_idx)
     drill_context = drill_context_from_group_config(field_group_config)
+
     {comp_mode, v1, v2} =
       determine_filter_comp_and_values(value, conf, drill_context)
       |> normalize_join_mode_filter_comp(conf)

--- a/lib/selecto_components/form/drill_down_filters.ex
+++ b/lib/selecto_components/form/drill_down_filters.ex
@@ -134,6 +134,10 @@ defmodule SelectoComponents.Form.DrillDownFilters do
       value == "__NULL__" ->
         {"IS_EMPTY", "", ""}
 
+      context.format in ["custom_buckets", :custom_buckets] && field_conf &&
+          Selecto.Temporal.date_like?(field_conf) ->
+        handle_custom_date_bucket_range(value)
+
       # Text prefix buckets from aggregate group-by
       text_prefix_context?(context) ->
         handle_text_prefix_bucket(value, context)
@@ -265,6 +269,10 @@ defmodule SelectoComponents.Form.DrillDownFilters do
 
   defp handle_bucket_range(value, field_conf, %{format: format, is_age_bucket: is_age_bucket}) do
     cond do
+      format in ["custom_buckets", :custom_buckets] && field_conf &&
+          Selecto.Temporal.date_like?(field_conf) ->
+        handle_custom_date_bucket_range(value)
+
       format in ["year_buckets", :year_buckets] && field_conf &&
           Selecto.Temporal.date_like?(field_conf) ->
         handle_year_bucket_range(value)
@@ -275,6 +283,40 @@ defmodule SelectoComponents.Form.DrillDownFilters do
 
       true ->
         handle_numeric_bucket_range(value)
+    end
+  end
+
+  defp handle_custom_date_bucket_range(value) do
+    today = Date.utc_today()
+
+    cond do
+      String.downcase(value) == "today" ->
+        {"DATE=", Date.to_iso8601(today), ""}
+
+      String.downcase(value) == "yesterday" ->
+        {"DATE=", Date.to_iso8601(Date.add(today, -1)), ""}
+
+      String.downcase(value) == "tomorrow" ->
+        {"DATE=", Date.to_iso8601(Date.add(today, 1)), ""}
+
+      String.match?(value, ~r/^(\d+)-(\d+)$/) ->
+        [min_days_str, max_days_str] = String.split(value, "-")
+        max_days = String.to_integer(max_days_str)
+        min_days = String.to_integer(min_days_str)
+        start_date = Date.add(today, -max_days)
+        end_date = Date.add(today, -(min_days - 1))
+        {"DATE_BETWEEN", Date.to_iso8601(start_date), Date.to_iso8601(end_date)}
+
+      String.match?(value, ~r/^(\d+)\+$/) ->
+        days = value |> String.replace("+", "") |> String.to_integer()
+        cutoff_date = Date.add(today, -days)
+        {"<=", Date.to_iso8601(cutoff_date), ""}
+
+      value == "Other" ->
+        {"=", "", ""}
+
+      true ->
+        {"=", value, ""}
     end
   end
 

--- a/lib/selecto_components/form/event_handlers.ex
+++ b/lib/selecto_components/form/event_handlers.ex
@@ -146,20 +146,7 @@ defmodule SelectoComponents.Form.EventHandlers do
             })
           end)
 
-        # Set up columns in the same format as view_from_params
-        raw_columns = Selecto.columns(selecto)
-
-        columns_list =
-          raw_columns
-          |> Enum.map(fn {key, col} ->
-            {key, col.name,
-             %{
-               type: Selecto.Temporal.date_like_type(col) || col.type,
-               format: Map.get(col, :format),
-               icon: Map.get(col, :icon),
-               icon_family: Map.get(col, :icon_family)
-             }}
-          end)
+        columns_list = SelectoComponents.Form.ColumnCatalog.picker_columns(selecto)
 
         initial_view_config = %{
           view_mode: default_view_mode,

--- a/lib/selecto_components/form/event_handlers/list_operations.ex
+++ b/lib/selecto_components/form/event_handlers/list_operations.ex
@@ -72,6 +72,7 @@ defmodule SelectoComponents.Form.EventHandlers.ListOperations do
             list,
             item_tuple
           )
+          |> ParamsState.sync_view_config_ctes(socket.assigns.selecto)
 
         socket = ParamsState.assign_view_config(socket, updated_view_config)
 
@@ -118,6 +119,7 @@ defmodule SelectoComponents.Form.EventHandlers.ListOperations do
             list,
             item
           )
+          |> ParamsState.sync_view_config_ctes(socket.assigns.selecto)
 
         socket = ParamsState.assign_view_config(socket, updated_view_config)
 
@@ -160,6 +162,7 @@ defmodule SelectoComponents.Form.EventHandlers.ListOperations do
             uuid,
             direction
           )
+          |> ParamsState.sync_view_config_ctes(socket.assigns.selecto)
 
         socket = ParamsState.assign_view_config(socket, updated_view_config)
 
@@ -207,6 +210,7 @@ defmodule SelectoComponents.Form.EventHandlers.ListOperations do
             dragged_uuid,
             target_uuid
           )
+          |> ParamsState.sync_view_config_ctes(socket.assigns.selecto)
 
         socket = ParamsState.assign_view_config(socket, updated_view_config)
 

--- a/lib/selecto_components/form/filter_rendering.ex
+++ b/lib/selecto_components/form/filter_rendering.ex
@@ -1614,89 +1614,136 @@ defmodule SelectoComponents.Form.FilterRendering do
         join_mode: join_mode,
         current_comp: current_comp,
         display_field: display_field,
-        filter_label: Map.get(join_mode_config, :name) || humanize_field(display_field)
+        filter_label: Map.get(join_mode_config, :name) || humanize_field(display_field),
+        promote_checked: promote_checked?(assigns.filter_value)
       )
 
     ~H"""
     <div class="space-y-2">
-      <%!-- Comparison operator selector --%>
-      <div class="flex items-center gap-2">
-        <select name={"filters[#{@uuid}][comp]"} class="sc-select text-sm">
-          <option value="IN" selected={@current_comp == "IN"}>Is One Of</option>
-          <option value="NOT IN" selected={@current_comp == "NOT IN"}>Is Not One Of</option>
-          <option value="IS NULL" selected={@current_comp == "IS NULL"}>Is Empty</option>
-          <option value="IS NOT NULL" selected={@current_comp == "IS NOT NULL"}>Is Not Empty</option>
-        </select>
-      </div>
-
-      <%= if @current_comp in ["IS NULL", "IS NOT NULL"] do %>
-        <div class="text-sm text-gray-500 italic">
-          No value selection needed
+      <div
+        class={[
+          "space-y-2",
+          @promote_checked && "opacity-60"
+        ]}
+        inert={@promote_checked}
+        aria-disabled={to_string(@promote_checked)}
+        data-promoted-lock={to_string(@promote_checked)}
+      >
+        <%!-- Comparison operator selector --%>
+        <div class="flex items-center gap-2">
+          <select name={"filters[#{@uuid}][comp]"} class="sc-select text-sm">
+            <option value="IN" selected={@current_comp == "IN"}>Is One Of</option>
+            <option value="NOT IN" selected={@current_comp == "NOT IN"}>Is Not One Of</option>
+            <option value="IS NULL" selected={@current_comp == "IS NULL"}>Is Empty</option>
+            <option value="IS NOT NULL" selected={@current_comp == "IS NOT NULL"}>Is Not Empty</option>
+          </select>
         </div>
-      <% else %>
-        <label class="text-sm font-medium text-gray-700">
-          Select {@filter_label}:
-        </label>
 
-        <%= if @join_mode == :lookup and length(@options) < 20 do %>
-          <%!-- Checkbox list for small datasets --%>
-          <div class="max-h-48 overflow-y-auto border border-gray-300 rounded-md p-2 bg-white space-y-1">
-            <%= for opt <- @options do %>
-              <label class="flex items-center space-x-2 hover:bg-blue-50 px-2 py-1 rounded cursor-pointer">
-                <input
-                  type="checkbox"
-                  name={"filters[#{@uuid}][selected_ids][]"}
-                  value={opt.id}
-                  checked={opt.id in @selected_ids}
-                  class="rounded border-gray-300 text-blue-600 focus:ring-blue-500 h-4 w-4"
-                />
-                <span class="text-sm text-gray-900">{opt.name}</span>
-              </label>
-            <% end %>
+        <%= if @current_comp in ["IS NULL", "IS NOT NULL"] do %>
+          <div class="text-sm text-gray-500 italic">
+            No value selection needed
           </div>
         <% else %>
-          <%!-- Simple multi-select for larger datasets --%>
-          <select
-            multiple
-            size="8"
-            name={"filters[#{@uuid}][selected_ids][]"}
-            phx-debounce="blur"
-            class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
-          >
-            <%= for opt <- @options do %>
-              <option value={opt.id} selected={opt.id in @selected_ids}>
-                {opt.name}
-              </option>
-            <% end %>
-          </select>
-          <p class="text-xs text-gray-500 mt-1">
-            Hold Ctrl/Cmd to select multiple. Click outside when done.
-          </p>
-        <% end %>
+          <label class="text-sm font-medium text-gray-700">
+            Select {@filter_label}:
+          </label>
 
-        <div class="text-xs text-gray-500">
-          {length(@selected_ids)} of {length(@options)} selected
-        </div>
-      <% end %>
+          <%= if @join_mode == :lookup and length(@options) < 20 do %>
+            <%!-- Checkbox list for small datasets --%>
+            <div class="max-h-48 overflow-y-auto border border-gray-300 rounded-md p-2 bg-white space-y-1">
+              <%= for opt <- @options do %>
+                <label class="flex items-center space-x-2 hover:bg-blue-50 px-2 py-1 rounded cursor-pointer">
+                  <input
+                    type="checkbox"
+                    name={"filters[#{@uuid}][selected_ids][]"}
+                    value={opt.id}
+                    checked={opt.id in @selected_ids}
+                    class="rounded border-gray-300 text-blue-600 focus:ring-blue-500 h-4 w-4"
+                  />
+                  <span class="text-sm text-gray-900">{opt.name}</span>
+                </label>
+              <% end %>
+            </div>
+          <% else %>
+            <%!-- Simple multi-select for larger datasets --%>
+            <select
+              multiple
+              size="8"
+              name={"filters[#{@uuid}][selected_ids][]"}
+              phx-debounce="blur"
+              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+            >
+              <%= for opt <- @options do %>
+                <option value={opt.id} selected={opt.id in @selected_ids}>
+                  {opt.name}
+                </option>
+              <% end %>
+            </select>
+            <p class="text-xs text-gray-500 mt-1">
+              Hold Ctrl/Cmd to select multiple. Click outside when done.
+            </p>
+          <% end %>
+
+          <div class="text-xs text-gray-500">
+            {length(@selected_ids)} of {length(@options)} selected
+          </div>
+
+          <%!-- Hidden field to store comma-separated IDs (only needed for IN/NOT IN) --%>
+          <%= if @current_comp in ["IN", "NOT IN"] do %>
+            <input
+              id={"filter-value-#{@uuid}"}
+              type="hidden"
+              name={"filters[#{@uuid}][value]"}
+              value={Enum.join(@selected_ids, ",")}
+            />
+          <% end %>
+        <% end %>
+      </div>
+
+      <p
+        :if={@promote_checked}
+        class="text-xs"
+        style="color: var(--sc-text-muted);"
+      >
+        Edited in View Controller.
+      </p>
+
+      <.promote_checkbox uuid={@uuid} checked={@promote_checked} />
 
       <%!-- Hidden inputs to preserve filter structure --%>
       <input type="hidden" name={"filters[#{@uuid}][uuid]"} value={@uuid} />
       <input type="hidden" name={"filters[#{@uuid}][section]"} value={@section} />
       <input type="hidden" name={"filters[#{@uuid}][index]"} value={@index} />
       <input type="hidden" name={"filters[#{@uuid}][filter]"} value={@filter_value["filter"]} />
-
-      <%!-- Hidden field to store comma-separated IDs (only needed for IN/NOT IN) --%>
-      <%= if @current_comp in ["IN", "NOT IN"] do %>
-        <input
-          id={"filter-value-#{@uuid}"}
-          type="hidden"
-          name={"filters[#{@uuid}][value]"}
-          value={Enum.join(@selected_ids, ",")}
-        />
-      <% end %>
     </div>
     """
   end
+
+  def join_mode_options(selecto, join_mode_config, limit \\ 100)
+
+  def join_mode_options(selecto, %{} = join_mode_config, limit) do
+    table = Map.get(join_mode_config, :source_table)
+    id_field = Map.get(join_mode_config, :id_field, :id)
+    display_field = Map.get(join_mode_config, :display_field, :name)
+    query_where = Map.get(join_mode_config, :query_where)
+    query_params = Map.get(join_mode_config, :query_params, [])
+
+    if table do
+      query_table_options(
+        selecto,
+        table,
+        id_field,
+        display_field,
+        limit,
+        query_where,
+        query_params
+      )
+    else
+      []
+    end
+  end
+
+  def join_mode_options(_selecto, _join_mode_config, _limit), do: []
 
   # Query database for ID+name pairs using Selecto's connection (Repo)
   defp query_table_options(

--- a/lib/selecto_components/form/filter_rendering.ex
+++ b/lib/selecto_components/form/filter_rendering.ex
@@ -16,6 +16,8 @@ defmodule SelectoComponents.Form.FilterRendering do
   use Phoenix.Component
   require Logger
 
+  alias SelectoComponents.SchemaUtils
+
   @identifier_regex ~r/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/
 
   @doc """
@@ -54,6 +56,16 @@ defmodule SelectoComponents.Form.FilterRendering do
       else
         filter_def
       end
+
+    filter_def =
+      if is_map(filter_def),
+        do: SchemaUtils.with_resolved_type(assigns.selecto, filter_def),
+        else: filter_def
+
+    column_def =
+      if is_map(column_def),
+        do: SchemaUtils.with_resolved_type(assigns.selecto, column_def),
+        else: column_def
 
     # Determine the field type
     field_type =
@@ -306,7 +318,9 @@ defmodule SelectoComponents.Form.FilterRendering do
                   <option value="next_month" selected={@filter_value["value"] == "next_month"}>
                     Next Month
                   </option>
-                  <option value="mtd" selected={@filter_value["value"] == "mtd"}>Month to Date</option>
+                  <option value="mtd" selected={@filter_value["value"] == "mtd"}>
+                    Month to Date
+                  </option>
                 </optgroup>
                 <optgroup label="Quarters">
                   <option value="this_quarter" selected={@filter_value["value"] == "this_quarter"}>
@@ -574,169 +588,170 @@ defmodule SelectoComponents.Form.FilterRendering do
         </select>
 
         <%= cond do %>
-        <% @current_comp == "BETWEEN" -> %>
-          <div class="col-span-2 grid grid-cols-2 gap-2">
-            <input
-              type="text"
-              name={"filters[#{@uuid}][value_start]"}
-              value={@between_start}
-              placeholder="Start"
-              class="sc-input"
-              phx-debounce="300"
-            />
-            <input
-              type="text"
-              name={"filters[#{@uuid}][value_end]"}
-              value={@between_end}
-              placeholder="End"
-              class="sc-input"
-              phx-debounce="300"
-            />
-          </div>
-        <% @supports_manual_in_values and @current_comp in ["IN", "NOT IN"] -> %>
-          <div
-            id={"filter-in-values-#{@uuid}-#{:erlang.phash2({@selected_in_values, @current_comp})}"}
-            class="col-span-2 space-y-2"
-          >
-            <textarea
-              id={"filter-pending-values-#{@uuid}"}
-              name={"filters[#{@uuid}][pending_values]"}
-              rows="3"
-              placeholder="Paste one value per line"
-              class="sc-input min-h-24 resize-y"
-              phx-debounce="300"
-              phx-hook=".FilterPendingValuesSync"
-              data-pending-value={@pending_in_values}
-              data-filter-uuid={@uuid}
-            >{@pending_in_values}</textarea>
+          <% @current_comp == "BETWEEN" -> %>
+            <div class="col-span-2 grid grid-cols-2 gap-2">
+              <input
+                type="text"
+                name={"filters[#{@uuid}][value_start]"}
+                value={@between_start}
+                placeholder="Start"
+                class="sc-input"
+                phx-debounce="300"
+              />
+              <input
+                type="text"
+                name={"filters[#{@uuid}][value_end]"}
+                value={@between_end}
+                placeholder="End"
+                class="sc-input"
+                phx-debounce="300"
+              />
+            </div>
+          <% @supports_manual_in_values and @current_comp in ["IN", "NOT IN"] -> %>
+            <div
+              id={"filter-in-values-#{@uuid}-#{:erlang.phash2({@selected_in_values, @current_comp})}"}
+              class="col-span-2 space-y-2"
+            >
+              <textarea
+                id={"filter-pending-values-#{@uuid}"}
+                name={"filters[#{@uuid}][pending_values]"}
+                rows="3"
+                placeholder="Paste one value per line"
+                class="sc-input min-h-24 resize-y"
+                phx-debounce="300"
+                phx-hook=".FilterPendingValuesSync"
+                data-pending-value={@pending_in_values}
+                data-filter-uuid={@uuid}
+              >{@pending_in_values}</textarea>
 
-            <input
-              type="hidden"
-              name={"filters[#{@uuid}][value]"}
-              value={Enum.join(@selected_in_values, ",")}
-            />
+              <input
+                type="hidden"
+                name={"filters[#{@uuid}][value]"}
+                value={Enum.join(@selected_in_values, ",")}
+              />
 
-            <%= if @selected_in_values != [] do %>
-              <div
-                class="rounded-md border p-2"
-                style="border-color: var(--sc-surface-border); background: var(--sc-surface-bg-alt);"
-              >
-                <div class="mb-2 flex items-center justify-between gap-2">
-                  <p class="text-xs font-medium" style="color: var(--sc-text-secondary);">
-                    {length(@selected_in_values)} selected value{if(length(@selected_in_values) == 1,
-                      do: "",
-                      else: "s"
-                    )}
-                  </p>
+              <%= if @selected_in_values != [] do %>
+                <div
+                  class="rounded-md border p-2"
+                  style="border-color: var(--sc-surface-border); background: var(--sc-surface-bg-alt);"
+                >
+                  <div class="mb-2 flex items-center justify-between gap-2">
+                    <p class="text-xs font-medium" style="color: var(--sc-text-secondary);">
+                      {length(@selected_in_values)} selected value{if(
+                        length(@selected_in_values) == 1,
+                        do: "",
+                        else: "s"
+                      )}
+                    </p>
 
-                  <button
-                    type="button"
-                    phx-click="clear_filter_selected_values"
-                    phx-value-filter-uuid={@uuid}
-                    class="text-xs font-medium underline-offset-2 hover:underline"
-                    style="color: var(--sc-accent);"
-                  >
-                    Uncheck all
-                  </button>
+                    <button
+                      type="button"
+                      phx-click="clear_filter_selected_values"
+                      phx-value-filter-uuid={@uuid}
+                      class="text-xs font-medium underline-offset-2 hover:underline"
+                      style="color: var(--sc-accent);"
+                    >
+                      Uncheck all
+                    </button>
+                  </div>
+
+                  <div class="max-h-40 space-y-1 overflow-y-auto pr-1">
+                    <button
+                      :for={selected_value <- @selected_in_values}
+                      id={"filter-selected-value-#{@uuid}-#{:erlang.phash2(selected_value)}"}
+                      type="button"
+                      phx-click="toggle_filter_selected_value"
+                      phx-value-filter-uuid={@uuid}
+                      phx-value-item={selected_value}
+                      class="flex w-full items-start gap-2 rounded px-2 py-1 text-left text-sm"
+                      style="color: var(--sc-text-primary);"
+                    >
+                      <input
+                        type="checkbox"
+                        checked
+                        disabled
+                        aria-hidden="true"
+                        class="pointer-events-none"
+                        style="margin-top: 0.15rem;"
+                      />
+                      <span class="break-all">{selected_value}</span>
+                    </button>
+                  </div>
                 </div>
+              <% else %>
+                <p class="text-xs" style="color: var(--sc-text-muted);">
+                  Paste values above to add them as selectable items.
+                </p>
+              <% end %>
 
-                <div class="max-h-40 space-y-1 overflow-y-auto pr-1">
-                  <button
-                    :for={selected_value <- @selected_in_values}
-                    id={"filter-selected-value-#{@uuid}-#{:erlang.phash2(selected_value)}"}
-                    type="button"
-                    phx-click="toggle_filter_selected_value"
-                    phx-value-filter-uuid={@uuid}
-                    phx-value-item={selected_value}
-                    class="flex w-full items-start gap-2 rounded px-2 py-1 text-left text-sm"
-                    style="color: var(--sc-text-primary);"
-                  >
-                    <input
-                      type="checkbox"
-                      checked
-                      disabled
-                      aria-hidden="true"
-                      class="pointer-events-none"
-                      style="margin-top: 0.15rem;"
-                    />
-                    <span class="break-all">{selected_value}</span>
-                  </button>
-                </div>
+              <script :type={Phoenix.LiveView.ColocatedHook} name=".FilterPendingValuesSync">
+                export default {
+                  commitPendingValues() {
+                    const pendingValue = this.el.value || "";
+
+                    if (pendingValue.trim() === "") {
+                      return;
+                    }
+
+                    this.pushEvent("commit_filter_pending_values", {
+                      "filter-uuid": this.el.dataset.filterUuid,
+                      "pending-values": pendingValue
+                    });
+                  },
+
+                  syncFromServer() {
+                    const pendingValue = this.el.dataset.pendingValue || "";
+
+                    if (this.el.value !== pendingValue) {
+                      this.el.value = pendingValue;
+                    }
+                  },
+
+                  mounted() {
+                    this.onBlur = () => this.commitPendingValues();
+                    this.el.addEventListener("blur", this.onBlur);
+                    this.syncFromServer();
+                  },
+
+                  updated() {
+                    this.syncFromServer();
+                  },
+
+                  destroyed() {
+                    if (this.onBlur) {
+                      this.el.removeEventListener("blur", this.onBlur);
+                    }
+                  }
+                };
+              </script>
+            </div>
+          <% @is_multi_select_id -> %>
+            <%!-- Multi-select ID filter input with helpful placeholder --%>
+            <div class="col-span-2">
+              <input
+                type="text"
+                name={"filters[#{@uuid}][value]"}
+                value={@filter_value["value"]}
+                placeholder="Enter IDs (comma-separated, e.g., 1,2,3)"
+                class="sc-input"
+                phx-debounce="300"
+                disabled={@current_comp in ["IS NULL", "IS NOT NULL"]}
+              />
+              <div class="mt-1 text-xs" style="color: var(--sc-accent);">
+                💡 Tip: Use numeric IDs for filtering (e.g., 1,2,3)
               </div>
-            <% else %>
-              <p class="text-xs" style="color: var(--sc-text-muted);">
-                Paste values above to add them as selectable items.
-              </p>
-            <% end %>
-
-            <script :type={Phoenix.LiveView.ColocatedHook} name=".FilterPendingValuesSync">
-              export default {
-                commitPendingValues() {
-                  const pendingValue = this.el.value || "";
-
-                  if (pendingValue.trim() === "") {
-                    return;
-                  }
-
-                  this.pushEvent("commit_filter_pending_values", {
-                    "filter-uuid": this.el.dataset.filterUuid,
-                    "pending-values": pendingValue
-                  });
-                },
-
-                syncFromServer() {
-                  const pendingValue = this.el.dataset.pendingValue || "";
-
-                  if (this.el.value !== pendingValue) {
-                    this.el.value = pendingValue;
-                  }
-                },
-
-                mounted() {
-                  this.onBlur = () => this.commitPendingValues();
-                  this.el.addEventListener("blur", this.onBlur);
-                  this.syncFromServer();
-                },
-
-                updated() {
-                  this.syncFromServer();
-                },
-
-                destroyed() {
-                  if (this.onBlur) {
-                    this.el.removeEventListener("blur", this.onBlur);
-                  }
-                }
-              };
-            </script>
-          </div>
-        <% @is_multi_select_id -> %>
-          <%!-- Multi-select ID filter input with helpful placeholder --%>
-          <div class="col-span-2">
+            </div>
+          <% true -> %>
+            <%!-- Standard text input --%>
             <input
               type="text"
               name={"filters[#{@uuid}][value]"}
               value={@filter_value["value"]}
-              placeholder="Enter IDs (comma-separated, e.g., 1,2,3)"
-              class="sc-input"
+              placeholder="Enter value..."
+              class="sc-input col-span-2"
               phx-debounce="300"
               disabled={@current_comp in ["IS NULL", "IS NOT NULL"]}
             />
-            <div class="mt-1 text-xs" style="color: var(--sc-accent);">
-              💡 Tip: Use numeric IDs for filtering (e.g., 1,2,3)
-            </div>
-          </div>
-        <% true -> %>
-          <%!-- Standard text input --%>
-          <input
-            type="text"
-            name={"filters[#{@uuid}][value]"}
-            value={@filter_value["value"]}
-            placeholder="Enter value..."
-            class="sc-input col-span-2"
-            phx-debounce="300"
-            disabled={@current_comp in ["IS NULL", "IS NOT NULL"]}
-          />
         <% end %>
 
         <%= if @is_text_field and @current_comp in ["=", "STARTS"] do %>
@@ -750,7 +765,9 @@ defmodule SelectoComponents.Form.FilterRendering do
               class="checkbox checkbox-sm"
               name={"filters[#{@uuid}][exclude_articles]"}
               value="true"
-              checked={Map.get(@filter_value, "exclude_articles", "false") in [true, "true", "on", "1"]}
+              checked={
+                Map.get(@filter_value, "exclude_articles", "false") in [true, "true", "on", "1"]
+              }
               style="border-color: var(--sc-surface-border); --chkbg: var(--sc-accent); --chkfg: var(--sc-surface-bg);"
             /> Ignore leading articles (a, an, the)
           </div>
@@ -813,6 +830,16 @@ defmodule SelectoComponents.Form.FilterRendering do
             {"<", "Less Than"},
             {"<=", "Less or Equal"},
             {"BETWEEN", "Between"},
+            {"IS NULL", "Is Empty"},
+            {"IS NOT NULL", "Is Not Empty"}
+          ]
+
+        :uuid ->
+          [
+            {"=", "Equals"},
+            {"!=", "Not Equals"},
+            {"IN", "Is One Of"},
+            {"NOT IN", "Is Not One Of"},
             {"IS NULL", "Is Empty"},
             {"IS NOT NULL", "Is Not Empty"}
           ]
@@ -1554,9 +1581,20 @@ defmodule SelectoComponents.Form.FilterRendering do
     join_mode = Map.get(join_mode_config, :join_mode, :lookup)
 
     # Query options from database using selecto's connection pool
+    query_where = Map.get(join_mode_config, :query_where)
+    query_params = Map.get(join_mode_config, :query_params, [])
+
     options =
       if table do
-        query_table_options(assigns.selecto, table, id_field, display_field, 100)
+        query_table_options(
+          assigns.selecto,
+          table,
+          id_field,
+          display_field,
+          100,
+          query_where,
+          query_params
+        )
       else
         []
       end
@@ -1575,7 +1613,8 @@ defmodule SelectoComponents.Form.FilterRendering do
         selected_ids: selected_ids,
         join_mode: join_mode,
         current_comp: current_comp,
-        display_field: display_field
+        display_field: display_field,
+        filter_label: Map.get(join_mode_config, :name) || humanize_field(display_field)
       )
 
     ~H"""
@@ -1596,7 +1635,7 @@ defmodule SelectoComponents.Form.FilterRendering do
         </div>
       <% else %>
         <label class="text-sm font-medium text-gray-700">
-          Select {@display_field}:
+          Select {@filter_label}:
         </label>
 
         <%= if @join_mode == :lookup and length(@options) < 20 do %>
@@ -1660,24 +1699,36 @@ defmodule SelectoComponents.Form.FilterRendering do
   end
 
   # Query database for ID+name pairs using Selecto's connection (Repo)
-  defp query_table_options(selecto, table, id_field, display_field, limit) do
+  defp query_table_options(
+         selecto,
+         table,
+         id_field,
+         display_field,
+         limit,
+         query_where,
+         query_params
+       ) do
     with {:ok, safe_table} <- safe_sql_identifier(table),
          {:ok, safe_id_field} <- safe_sql_identifier(id_field),
          {:ok, safe_display_field} <- safe_sql_identifier(display_field) do
+      where_clause =
+        if is_binary(query_where) and query_where != "", do: "AND #{query_where}", else: ""
+
       query = """
       SELECT #{safe_id_field} as id, #{safe_display_field} as name
       FROM #{safe_table}
       WHERE #{safe_display_field} IS NOT NULL
+      #{where_clause}
       ORDER BY #{safe_display_field}
       LIMIT $1
       """
 
       connection = selecto.connection
 
-      case execute_options_query(connection, query, [limit]) do
+      case execute_options_query(connection, query, [limit | query_params]) do
         {:ok, %{rows: rows}} ->
           Enum.map(rows, fn [id, name] ->
-            %{id: id, name: to_string(name)}
+            %{id: normalize_option_id(id), name: to_string(name)}
           end)
 
         {:error, error} ->
@@ -1722,6 +1773,26 @@ defmodule SelectoComponents.Form.FilterRendering do
     end
   end
 
+  defp normalize_option_id(id) when is_binary(id) do
+    case Ecto.UUID.load(id) do
+      {:ok, uuid} -> uuid
+      :error -> id
+    end
+  end
+
+  defp normalize_option_id(id), do: to_string(id)
+
+  defp humanize_field(field) when is_atom(field),
+    do: field |> Atom.to_string() |> humanize_field()
+
+  defp humanize_field(field) when is_binary(field) do
+    field
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp humanize_field(field), do: to_string(field)
+
   defp safe_sql_identifier(value) when is_atom(value),
     do: safe_sql_identifier(Atom.to_string(value))
 
@@ -1743,13 +1814,6 @@ defmodule SelectoComponents.Form.FilterRendering do
     |> String.split(",")
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
-    |> Enum.map(fn id_str ->
-      case Integer.parse(id_str) do
-        {id, _} -> id
-        :error -> nil
-      end
-    end)
-    |> Enum.reject(&is_nil/1)
   end
 
   defp parse_filter_ids(_), do: []

--- a/lib/selecto_components/form/filter_rendering.ex
+++ b/lib/selecto_components/form/filter_rendering.ex
@@ -1447,7 +1447,8 @@ defmodule SelectoComponents.Form.FilterRendering do
   def build_filter_list(selecto) do
     # Include explicit filters and only columns that are marked as filterable
     filterable_columns =
-      Map.values(Selecto.columns(selecto))
+      Selecto.columns(selecto)
+      |> Enum.map(fn {colid, column} -> Map.put_new(column, :colid, colid) end)
       |> Enum.filter(fn column ->
         # Only include columns that are explicitly marked as filterable
         # or don't have component formatting (which indicates they're display-only)

--- a/lib/selecto_components/form/list_picker_operations.ex
+++ b/lib/selecto_components/form/list_picker_operations.ex
@@ -10,6 +10,7 @@ defmodule SelectoComponents.Form.ListPickerOperations do
   """
 
   alias SelectoComponents.SafeAtom
+  alias SelectoComponents.Form.ColumnCatalog
   alias SelectoComponents.Views.Runtime, as: ViewRuntime
 
   @doc """
@@ -32,7 +33,6 @@ defmodule SelectoComponents.Form.ListPickerOperations do
         _ -> true
       end)
 
-    # Update the view_config
     put_in(view_config.views[view][list], filtered_list)
   end
 
@@ -115,6 +115,7 @@ defmodule SelectoComponents.Form.ListPickerOperations do
         {dragged_item, remaining_items} = List.pop_at(item_list, dragged_index)
 
         reordered_items = List.insert_at(remaining_items, target_index, dragged_item)
+
         put_in(view_config.views[view][list], reordered_items)
     end
   end
@@ -134,7 +135,6 @@ defmodule SelectoComponents.Form.ListPickerOperations do
     # Append the new item
     updated_list = current_list ++ [item]
 
-    # Update the view_config
     put_in(view_config.views[view][list], updated_list)
   end
 
@@ -151,9 +151,9 @@ defmodule SelectoComponents.Form.ListPickerOperations do
     Phoenix.LiveView.send_update(ViewRuntime.form_component(view_module),
       id: component_id,
       view_config: updated_view_config,
-      columns: socket_assigns.columns,
+      columns: ColumnCatalog.picker_columns(socket_assigns.selecto),
       view: view_module,
-      selecto: socket_assigns.selecto
+      selecto: ColumnCatalog.picker_selecto(socket_assigns.selecto)
     )
   end
 end

--- a/lib/selecto_components/form/params_state.ex
+++ b/lib/selecto_components/form/params_state.ex
@@ -50,11 +50,13 @@ defmodule SelectoComponents.Form.ParamsState do
   """
   def view_config_to_params(view_config) do
     view_mode = get_map_value(view_config, :view_mode, "aggregate")
+    ctes = get_map_value(view_config, :ctes, [])
     filters = get_map_value(view_config, :filters, [])
     views = get_map_value(view_config, :views, %{})
 
     params = %{
       "view_mode" => view_mode,
+      "ctes" => ctes_to_params(ctes),
       "filters" => filters_to_params(filters)
     }
 
@@ -96,6 +98,7 @@ defmodule SelectoComponents.Form.ParamsState do
   def view_config_to_saved_params(view_config) when is_map(view_config) do
     %{
       "view_mode" => get_map_value(view_config, :view_mode, "aggregate"),
+      "ctes" => normalize_saved_ctes_for_storage(get_map_value(view_config, :ctes, [])),
       "filters" => normalize_saved_filters_for_storage(get_map_value(view_config, :filters, [])),
       "views" => normalize_saved_views_for_storage(get_map_value(view_config, :views, %{}))
     }
@@ -133,6 +136,39 @@ defmodule SelectoComponents.Form.ParamsState do
         item_acc
     end)
   end
+
+  defp ctes_to_params(ctes) when is_list(ctes) do
+    ctes
+    |> Enum.with_index()
+    |> Enum.reduce(%{}, fn
+      {{uuid, name, config}, index}, acc ->
+        Map.put(
+          acc,
+          compact_param_key(index),
+          Map.merge(stringify_map_keys(config), %{
+            "uuid" => uuid,
+            "name" => name,
+            "index" => to_string(index)
+          })
+        )
+
+      {[uuid, name, config], index}, acc ->
+        Map.put(
+          acc,
+          compact_param_key(index),
+          Map.merge(stringify_map_keys(config), %{
+            "uuid" => uuid,
+            "name" => name,
+            "index" => to_string(index)
+          })
+        )
+
+      {_unknown_item, _index}, acc ->
+        acc
+    end)
+  end
+
+  defp ctes_to_params(_ctes), do: %{}
 
   defp merge_scalar_view_param(acc, :aggregate, key, value)
        when key in [:per_page, "per_page"] do
@@ -562,6 +598,7 @@ defmodule SelectoComponents.Form.ParamsState do
             adapter: old_selecto.adapter,
             validate: false
           )
+          |> maybe_apply_ctes(params)
 
         raw_columns = Selecto.columns(selecto)
 
@@ -633,7 +670,9 @@ defmodule SelectoComponents.Form.ParamsState do
               raise "View mode '#{selected_view}' not found in configured views"
           end
 
-        selecto = Map.put(selecto, :set, view_set)
+        selecto =
+          selecto
+          |> Map.put(:set, Map.merge(Map.get(selecto, :set, %{}), view_set))
 
         view_mode = Map.get(params, "view_mode", "detail")
         selected_columns = SelectoComponents.Form.get_selected_columns_from_params(params)
@@ -1397,6 +1436,7 @@ defmodule SelectoComponents.Form.ParamsState do
     params = canonicalize_form_params(params)
     filters = view_filter_process(params, "filters")
     existing_config = socket.assigns[:view_config] || %{}
+    ctes = ctes_from_params(params, get_map_value(existing_config, :ctes, []))
 
     selected_view =
       SafeAtom.to_view_mode(
@@ -1416,6 +1456,7 @@ defmodule SelectoComponents.Form.ParamsState do
     assign_view_config(
       socket,
       Map.merge(existing_config, %{
+        ctes: ctes,
         filters: filters,
         views: view_configs,
         view_mode: Map.get(params, "view_mode", existing_config[:view_mode] || "aggregate")
@@ -1433,6 +1474,7 @@ defmodule SelectoComponents.Form.ParamsState do
     params = canonicalize_form_params(params)
     existing_config = socket.assigns[:view_config] || %{}
     stale_submit? = stale_form_submit?(params, socket)
+    ctes = ctes_from_params(params, get_map_value(existing_config, :ctes, []))
     filters = submitted_filters_state(params, existing_config, stale_submit?)
 
     view_configs =
@@ -1448,6 +1490,7 @@ defmodule SelectoComponents.Form.ParamsState do
     assign_view_config(
       socket,
       Map.merge(existing_config, %{
+        ctes: ctes,
         filters: filters,
         views: view_configs,
         view_mode: Map.get(params, "view_mode", existing_config[:view_mode] || "aggregate")
@@ -1469,6 +1512,7 @@ defmodule SelectoComponents.Form.ParamsState do
             :view_mode,
             get_map_value(existing_config, :view_mode, "aggregate")
           ),
+        ctes: normalize_saved_ctes_from_storage(get_map_value(saved_params, :ctes, [])),
         filters: normalize_saved_filters_from_storage(get_map_value(saved_params, :filters, [])),
         views: restore_saved_views(saved_params, existing_config, socket)
       }
@@ -1758,6 +1802,9 @@ defmodule SelectoComponents.Form.ParamsState do
 
   defp normalize_saved_views_for_storage(_views), do: %{}
 
+  defp normalize_saved_ctes_for_storage(ctes) when is_list(ctes), do: normalize_saved_term(ctes)
+  defp normalize_saved_ctes_for_storage(_ctes), do: []
+
   defp normalize_saved_filters_for_storage(filters) when is_list(filters) do
     Enum.map(filters, &normalize_saved_term/1)
   end
@@ -1784,6 +1831,9 @@ defmodule SelectoComponents.Form.ParamsState do
   end
 
   defp normalize_saved_filters_from_storage(_filters), do: []
+
+  defp normalize_saved_ctes_from_storage(ctes) when is_list(ctes), do: ctes
+  defp normalize_saved_ctes_from_storage(_ctes), do: []
 
   defp restore_saved_views(saved_params, existing_config, socket) do
     Enum.reduce(socket.assigns.views, %{}, fn {view, _module, _name, _opt} = view_tuple, acc ->
@@ -1990,7 +2040,8 @@ defmodule SelectoComponents.Form.ParamsState do
 
     # Convert the view-specific lists to params format
     params = %{
-      "view_mode" => view_type
+      "view_mode" => view_type,
+      "ctes" => ctes_to_params(get_map_value(saved_params, :ctes, []))
     }
 
     # Convert selected items
@@ -2475,8 +2526,51 @@ defmodule SelectoComponents.Form.ParamsState do
   end
 
   defp url_compactable_keys do
-    ["filters", "selected", "order_by", "group_by", "aggregate", "x_axis", "y_axis", "series"]
+    ["ctes", "filters", "selected", "order_by", "group_by", "aggregate", "x_axis", "y_axis", "series"]
   end
+
+  defp maybe_apply_ctes(selecto, params) when is_map(params) do
+    params
+    |> ctes_from_params([])
+    |> Enum.reduce(selecto, fn
+      {_, name, _}, acc when is_binary(name) and name != "" ->
+        Selecto.with_cte(acc, name)
+
+      [_, name, _], acc when is_binary(name) and name != "" ->
+        Selecto.with_cte(acc, name)
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp maybe_apply_ctes(selecto, _params), do: selecto
+
+  defp ctes_from_params(params, default) when is_map(params) do
+    case Map.get(params, "ctes") do
+      section when is_map(section) ->
+        section
+        |> Enum.sort_by(fn {_uuid, value} -> sort_index_for_compaction(value) end)
+        |> Enum.map(fn {uuid, value} ->
+          cte_uuid = get_map_value(value, :uuid, uuid)
+          name = get_map_value(value, :name)
+
+          {cte_uuid, name, Map.drop(stringify_map_keys(value), ["uuid", "name", "index"])}
+        end)
+        |> Enum.reject(fn {_uuid, name, _config} -> is_nil(name) or to_string(name) == "" end)
+
+      _ ->
+        default
+    end
+  end
+
+  defp ctes_from_params(_params, default), do: default
+
+  defp stringify_map_keys(map) when is_map(map) do
+    Map.new(map, fn {key, value} -> {to_string(key), value} end)
+  end
+
+  defp stringify_map_keys(_value), do: %{}
 
   defp sort_index_for_compaction(value) when is_map(value) do
     case Map.get(value, "index") do

--- a/lib/selecto_components/form/params_state.ex
+++ b/lib/selecto_components/form/params_state.ex
@@ -1940,18 +1940,24 @@ defmodule SelectoComponents.Form.ParamsState do
       |> String.trim()
       |> String.upcase()
 
-    case {comp, Map.get(promoted_values, "value")} do
-      {comp, value} when comp in ["IN", "NOT IN"] and is_binary(value) ->
-        Map.put(promoted_values, "value", normalize_promoted_multi_value(value))
-
-      _ ->
-        promoted_values
+    if comp in ["IN", "NOT IN"] do
+      Map.put(promoted_values, "value", normalize_promoted_multi_value(Map.get(promoted_values, "value")))
+    else
+      promoted_values
     end
   end
 
   defp normalize_promoted_multi_value(value) when is_binary(value) do
     value
     |> String.split(~r/[\r\n,]+/)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join(",")
+  end
+
+  defp normalize_promoted_multi_value(value) when is_list(value) do
+    value
+    |> Enum.map(&to_string/1)
     |> Enum.map(&String.trim/1)
     |> Enum.reject(&(&1 == ""))
     |> Enum.join(",")

--- a/lib/selecto_components/form/params_state.ex
+++ b/lib/selecto_components/form/params_state.ex
@@ -602,17 +602,7 @@ defmodule SelectoComponents.Form.ParamsState do
 
         raw_columns = Selecto.columns(selecto)
 
-        columns_list =
-          raw_columns
-          |> Enum.map(fn {key, col} ->
-            {key, col.name,
-             %{
-               type: Selecto.Temporal.date_like_type(col) || col.type,
-               format: Map.get(col, :format),
-               icon: Map.get(col, :icon),
-               icon_family: Map.get(col, :icon_family)
-             }}
-          end)
+        columns_list = SelectoComponents.Form.ColumnCatalog.picker_columns(selecto)
 
         columns_map =
           raw_columns
@@ -1436,7 +1426,6 @@ defmodule SelectoComponents.Form.ParamsState do
     params = canonicalize_form_params(params)
     filters = view_filter_process(params, "filters")
     existing_config = socket.assigns[:view_config] || %{}
-    ctes = ctes_from_params(params, get_map_value(existing_config, :ctes, []))
 
     selected_view =
       SafeAtom.to_view_mode(
@@ -1452,15 +1441,16 @@ defmodule SelectoComponents.Form.ParamsState do
       end)
       |> preserve_missing_detail_view_params(existing_config, params)
 
-    # Preserve existing view_config and only update what's in params
-    assign_view_config(
-      socket,
+    provisional_config =
       Map.merge(existing_config, %{
-        ctes: ctes,
         filters: filters,
         views: view_configs,
         view_mode: Map.get(params, "view_mode", existing_config[:view_mode] || "aggregate")
       })
+
+    assign_view_config(
+      socket,
+      sync_view_config_ctes(provisional_config, socket.assigns[:selecto])
     )
   end
 
@@ -1474,7 +1464,6 @@ defmodule SelectoComponents.Form.ParamsState do
     params = canonicalize_form_params(params)
     existing_config = socket.assigns[:view_config] || %{}
     stale_submit? = stale_form_submit?(params, socket)
-    ctes = ctes_from_params(params, get_map_value(existing_config, :ctes, []))
     filters = submitted_filters_state(params, existing_config, stale_submit?)
 
     view_configs =
@@ -1487,14 +1476,16 @@ defmodule SelectoComponents.Form.ParamsState do
       end)
       |> preserve_missing_detail_view_params(existing_config, params)
 
-    assign_view_config(
-      socket,
+    provisional_config =
       Map.merge(existing_config, %{
-        ctes: ctes,
         filters: filters,
         views: view_configs,
         view_mode: Map.get(params, "view_mode", existing_config[:view_mode] || "aggregate")
       })
+
+    assign_view_config(
+      socket,
+      sync_view_config_ctes(provisional_config, socket.assigns[:selecto])
     )
   end
 
@@ -1512,18 +1503,32 @@ defmodule SelectoComponents.Form.ParamsState do
             :view_mode,
             get_map_value(existing_config, :view_mode, "aggregate")
           ),
-        ctes: normalize_saved_ctes_from_storage(get_map_value(saved_params, :ctes, [])),
         filters: normalize_saved_filters_from_storage(get_map_value(saved_params, :filters, [])),
         views: restore_saved_views(saved_params, existing_config, socket)
       }
 
-      assign_view_config(socket, Map.merge(existing_config, restored_config))
+      socket
+      |> assign_view_config(
+        existing_config
+        |> Map.merge(restored_config)
+        |> sync_view_config_ctes(socket.assigns[:selecto])
+      )
     else
       params_to_state(saved_params, socket)
     end
   end
 
   def saved_params_to_state(saved_params, socket), do: params_to_state(saved_params, socket)
+
+  def sync_view_config_ctes(view_config, %Selecto{} = selecto) when is_map(view_config) do
+    derived_names = derived_cte_names_from_view_config(view_config, selecto)
+    existing_ctes = get_map_value(view_config, :ctes, [])
+    synced_ctes = build_cte_entries(derived_names, existing_ctes)
+
+    Map.put(view_config, :ctes, synced_ctes)
+  end
+
+  def sync_view_config_ctes(view_config, _selecto), do: view_config
 
   defp submitted_view_state(view, view_tuple, params, existing_config, socket, stale_submit?) do
     existing_view = get_in(existing_config, [:views, view])
@@ -1832,9 +1837,6 @@ defmodule SelectoComponents.Form.ParamsState do
 
   defp normalize_saved_filters_from_storage(_filters), do: []
 
-  defp normalize_saved_ctes_from_storage(ctes) when is_list(ctes), do: ctes
-  defp normalize_saved_ctes_from_storage(_ctes), do: []
-
   defp restore_saved_views(saved_params, existing_config, socket) do
     Enum.reduce(socket.assigns.views, %{}, fn {view, _module, _name, _opt} = view_tuple, acc ->
       restored_view =
@@ -1991,7 +1993,11 @@ defmodule SelectoComponents.Form.ParamsState do
       |> String.upcase()
 
     if comp in ["IN", "NOT IN"] do
-      Map.put(promoted_values, "value", normalize_promoted_multi_value(Map.get(promoted_values, "value")))
+      Map.put(
+        promoted_values,
+        "value",
+        normalize_promoted_multi_value(Map.get(promoted_values, "value"))
+      )
     else
       promoted_values
     end
@@ -2526,20 +2532,38 @@ defmodule SelectoComponents.Form.ParamsState do
   end
 
   defp url_compactable_keys do
-    ["ctes", "filters", "selected", "order_by", "group_by", "aggregate", "x_axis", "y_axis", "series"]
+    [
+      "ctes",
+      "filters",
+      "selected",
+      "order_by",
+      "group_by",
+      "aggregate",
+      "x_axis",
+      "y_axis",
+      "series"
+    ]
   end
 
   defp maybe_apply_ctes(selecto, params) when is_map(params) do
-    params
-    |> ctes_from_params([])
-    |> Enum.reduce(selecto, fn
-      {_, name, _}, acc when is_binary(name) and name != "" ->
-        Selecto.with_cte(acc, name)
+    explicit_names =
+      params
+      |> ctes_from_params([])
+      |> Enum.map(&cte_entry_name/1)
+      |> Enum.reject(&is_nil/1)
 
-      [_, name, _], acc when is_binary(name) and name != "" ->
-        Selecto.with_cte(acc, name)
+    derived_names = derived_cte_names_from_params(params, selecto)
 
-      _, acc ->
+    Enum.reduce(explicit_names ++ derived_names, selecto, fn
+      name, acc when is_binary(name) and name != "" ->
+        if name in SelectoComponents.Form.ColumnCatalog.available_cte_names(acc) and
+             not cte_already_applied?(acc, name) do
+          Selecto.with_cte(acc, name)
+        else
+          acc
+        end
+
+      _name, acc ->
         acc
     end)
   end
@@ -2565,6 +2589,149 @@ defmodule SelectoComponents.Form.ParamsState do
   end
 
   defp ctes_from_params(_params, default), do: default
+
+  defp derived_cte_names_from_params(params, %Selecto{} = selecto) when is_map(params) do
+    field_ids =
+      params
+      |> field_ids_from_params()
+      |> Kernel.++(filter_ids_from_params(params))
+
+    SelectoComponents.Form.ColumnCatalog.required_cte_names_for_fields(selecto, field_ids)
+  end
+
+  defp derived_cte_names_from_params(_params, _selecto), do: []
+
+  defp derived_cte_names_from_view_config(view_config, %Selecto{} = selecto)
+       when is_map(view_config) do
+    field_ids =
+      view_config
+      |> field_ids_from_view_config()
+      |> Kernel.++(filter_ids_from_view_config(view_config))
+
+    SelectoComponents.Form.ColumnCatalog.required_cte_names_for_fields(selecto, field_ids)
+  end
+
+  defp derived_cte_names_from_view_config(_view_config, _selecto), do: []
+
+  defp field_ids_from_params(params) when is_map(params) do
+    ["selected", "order_by", "group_by", "aggregate", "x_axis", "y_axis", "series"]
+    |> Enum.flat_map(fn section ->
+      params
+      |> Map.get(section, %{})
+      |> list_field_ids_from_param_section()
+    end)
+  end
+
+  defp field_ids_from_params(_params), do: []
+
+  defp list_field_ids_from_param_section(section) when is_map(section) do
+    section
+    |> Map.values()
+    |> Enum.map(&get_map_value(&1, :field))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp list_field_ids_from_param_section(_section), do: []
+
+  defp filter_ids_from_params(params) when is_map(params) do
+    params
+    |> Map.get("filters", %{})
+    |> Map.values()
+    |> Enum.map(&get_map_value(&1, :filter))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp filter_ids_from_params(_params), do: []
+
+  defp field_ids_from_view_config(view_config) when is_map(view_config) do
+    view_config
+    |> get_map_value(:views, %{})
+    |> Map.values()
+    |> Enum.flat_map(&field_ids_from_view_state/1)
+  end
+
+  defp field_ids_from_view_config(_view_config), do: []
+
+  defp field_ids_from_view_state(view_state) when is_map(view_state) do
+    [:selected, :order_by, :group_by, :aggregate, :x_axis, :y_axis, :series]
+    |> Enum.flat_map(fn key ->
+      view_state
+      |> get_map_value(key, [])
+      |> list_field_ids_from_items()
+    end)
+  end
+
+  defp field_ids_from_view_state(_view_state), do: []
+
+  defp list_field_ids_from_items(items) when is_list(items) do
+    Enum.map(items, fn
+      {_uuid, field, _config} -> field
+      [_, field, _config] -> field
+      _other -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp list_field_ids_from_items(_items), do: []
+
+  defp filter_ids_from_view_config(view_config) when is_map(view_config) do
+    view_config
+    |> get_map_value(:filters, [])
+    |> Enum.map(fn
+      {_uuid, _section, filter_value} -> get_map_value(filter_value, :filter)
+      [_, _, filter_value] -> get_map_value(filter_value, :filter)
+      _other -> nil
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp filter_ids_from_view_config(_view_config), do: []
+
+  defp build_cte_entries(names, existing_ctes) when is_list(names) do
+    existing_by_name =
+      Map.new(existing_ctes, fn entry ->
+        case normalize_cte_entry(entry) do
+          {uuid, name, config} -> {name, {uuid, name, config}}
+          nil -> {nil, nil}
+        end
+      end)
+
+    names
+    |> Enum.uniq()
+    |> Enum.map(fn name ->
+      Map.get(existing_by_name, name, {"auto-cte-#{name}", name, %{}})
+    end)
+  end
+
+  defp build_cte_entries(_names, _existing_ctes), do: []
+
+  defp normalize_cte_entry({uuid, name, config}),
+    do: {to_string(uuid), to_string(name), config || %{}}
+
+  defp normalize_cte_entry([uuid, name, config]),
+    do: {to_string(uuid), to_string(name), config || %{}}
+
+  defp normalize_cte_entry(_entry), do: nil
+
+  defp cte_entry_name({_, name, _}) when is_binary(name), do: name
+  defp cte_entry_name([_, name, _]) when is_binary(name), do: name
+  defp cte_entry_name(_entry), do: nil
+
+  defp cte_already_applied?(%Selecto{} = selecto, name) do
+    selecto
+    |> get_in([Access.key(:set, %{}), Access.key(:ctes, [])])
+    |> Enum.any?(fn spec ->
+      spec_name =
+        Map.get(spec, :name) ||
+          Map.get(spec, :as) ||
+          Map.get(spec, "name") ||
+          Map.get(spec, "as")
+
+      to_string(spec_name || "") == name
+    end)
+  end
+
+  defp cte_already_applied?(_selecto, _name), do: false
 
   defp stringify_map_keys(map) when is_map(map) do
     Map.new(map, fn {key, value} -> {to_string(key), value} end)

--- a/lib/selecto_components/form/promoted_filter_editor.ex
+++ b/lib/selecto_components/form/promoted_filter_editor.ex
@@ -311,7 +311,9 @@ defmodule SelectoComponents.Form.PromotedFilterEditor do
   defp filter_badge_label(%{render_kind: :text_search}), do: "Text Search"
   defp filter_badge_label(filter), do: filter_comp_label(filter.comp)
 
-  defp promoted_multiselect_filter?(%{field_conf: %{join_mode: join_mode, filter_type: :multi_select_id}})
+  defp promoted_multiselect_filter?(%{
+         field_conf: %{join_mode: join_mode, filter_type: :multi_select_id}
+       })
        when join_mode in [:lookup, :star, :tag],
        do: true
 

--- a/lib/selecto_components/form/promoted_filter_editor.ex
+++ b/lib/selecto_components/form/promoted_filter_editor.ex
@@ -6,14 +6,16 @@ defmodule SelectoComponents.Form.PromotedFilterEditor do
 
   attr(:filter, :map, required: true)
   attr(:theme, :map, required: true)
+  attr(:selecto, :any, required: true)
 
   def editor(assigns) do
     assigns = assign(assigns, :comp_label, filter_badge_label(assigns.filter))
 
-    case assigns.filter.render_kind do
-      :datetime -> datetime_filter_editor(assigns)
-      :text_search -> text_search_filter_editor(assigns)
-      _ -> standard_filter_editor(assigns)
+    cond do
+      promoted_multiselect_filter?(assigns.filter) -> multiselect_filter_editor(assigns)
+      assigns.filter.render_kind == :datetime -> datetime_filter_editor(assigns)
+      assigns.filter.render_kind == :text_search -> text_search_filter_editor(assigns)
+      true -> standard_filter_editor(assigns)
     end
   end
 
@@ -74,6 +76,56 @@ defmodule SelectoComponents.Form.PromotedFilterEditor do
             class={Theme.slot(@theme, :input)}
             phx-debounce="300"
           />
+      <% end %>
+    </div>
+    """
+  end
+
+  attr(:filter, :map, required: true)
+  attr(:theme, :map, required: true)
+  attr(:selecto, :any, required: true)
+
+  defp multiselect_filter_editor(assigns) do
+    options = FilterRendering.join_mode_options(assigns.selecto, assigns.filter.field_conf)
+
+    assigns =
+      assigns
+      |> assign(
+        options: options,
+        selected_ids: parse_selected_ids(assigns.filter.value),
+        current_comp: normalize_multiselect_comp(assigns.filter.comp)
+      )
+
+    ~H"""
+    <div class="space-y-2">
+      <span
+        class="inline-flex shrink-0 items-center rounded-full px-2 py-1 text-[0.7rem] font-medium uppercase tracking-[0.12em]"
+        style="background: color-mix(in srgb, var(--sc-primary) 14%, transparent); color: var(--sc-primary);"
+      >
+        {@comp_label}
+      </span>
+
+      <%= if @current_comp in ["IS NULL", "IS NOT NULL"] do %>
+        <p class="text-sm" style="color: var(--sc-text-muted);">
+          No value needed for this filter.
+        </p>
+      <% else %>
+        <input type="hidden" name={"promoted_filters[#{@filter.uuid}][value][]"} value="" />
+        <select
+          multiple
+          size="6"
+          name={"promoted_filters[#{@filter.uuid}][value][]"}
+          class={Theme.slot(@theme, :input) <> " min-h-32"}
+        >
+          <%= for opt <- @options do %>
+            <option value={opt.id} selected={opt.id in @selected_ids}>
+              {opt.name}
+            </option>
+          <% end %>
+        </select>
+        <p class="text-xs" style="color: var(--sc-text-muted);">
+          Hold Ctrl/Cmd to select multiple.
+        </p>
       <% end %>
     </div>
     """
@@ -258,6 +310,39 @@ defmodule SelectoComponents.Form.PromotedFilterEditor do
 
   defp filter_badge_label(%{render_kind: :text_search}), do: "Text Search"
   defp filter_badge_label(filter), do: filter_comp_label(filter.comp)
+
+  defp promoted_multiselect_filter?(%{field_conf: %{join_mode: join_mode, filter_type: :multi_select_id}})
+       when join_mode in [:lookup, :star, :tag],
+       do: true
+
+  defp promoted_multiselect_filter?(_filter), do: false
+
+  defp parse_selected_ids(value) when is_binary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp parse_selected_ids(value) when is_list(value) do
+    value
+    |> Enum.map(&to_string/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp parse_selected_ids(_value), do: []
+
+  defp normalize_multiselect_comp(comp) when is_binary(comp) do
+    comp
+    |> String.trim()
+    |> String.upcase()
+  end
+
+  defp normalize_multiselect_comp(comp) when is_atom(comp),
+    do: comp |> Atom.to_string() |> normalize_multiselect_comp()
+
+  defp normalize_multiselect_comp(_comp), do: "IN"
 
   defp weekday_options do
     [

--- a/lib/selecto_components/helpers/bucket_parser.ex
+++ b/lib/selecto_components/helpers/bucket_parser.ex
@@ -69,12 +69,24 @@ defmodule SelectoComponents.Helpers.BucketParser do
       else
         case_clauses =
           Enum.map(ranges, fn
+            {min, max, label} when field_type in [:date, :datetime] and is_integer(min) and is_integer(max) ->
+              date_expr = "DATE(#{field_name})"
+
+              if min == max do
+                "WHEN #{date_expr} = CURRENT_DATE - INTERVAL '#{min} day' THEN '#{label}'"
+              else
+                "WHEN #{date_expr} BETWEEN CURRENT_DATE - INTERVAL '#{max} day' AND CURRENT_DATE - INTERVAL '#{min} day' THEN '#{label}'"
+              end
+
             {min, max, label} when is_integer(min) and is_integer(max) ->
               if min == max do
                 "WHEN #{field_name} = #{min} THEN '#{label}'"
               else
                 "WHEN #{field_name} >= #{min} AND #{field_name} <= #{max} THEN '#{label}'"
               end
+
+            {min, :infinity, label} when field_type in [:date, :datetime] ->
+              "WHEN DATE(#{field_name}) <= CURRENT_DATE - INTERVAL '#{min} day' THEN '#{label}'"
 
             {min, :infinity, label} ->
               # For "11+" we want >= 11, not > 11

--- a/lib/selecto_components/helpers/bucket_parser.ex
+++ b/lib/selecto_components/helpers/bucket_parser.ex
@@ -69,7 +69,8 @@ defmodule SelectoComponents.Helpers.BucketParser do
       else
         case_clauses =
           Enum.map(ranges, fn
-            {min, max, label} when field_type in [:date, :datetime] and is_integer(min) and is_integer(max) ->
+            {min, max, label}
+            when field_type in [:date, :datetime] and is_integer(min) and is_integer(max) ->
               date_expr = "DATE(#{field_name})"
 
               if min == max do

--- a/lib/selecto_components/helpers/filters.ex
+++ b/lib/selecto_components/helpers/filters.ex
@@ -1,5 +1,6 @@
 defmodule SelectoComponents.Helpers.Filters do
   alias SelectoComponents.Helpers.BucketParser
+  alias SelectoComponents.SchemaUtils
 
   ## For cast
   import Ecto.Type
@@ -301,6 +302,115 @@ defmodule SelectoComponents.Helpers.Filters do
         raise ArgumentError, "unsupported string comparison operator #{inspect(comp_norm)}"
     end
   end
+
+  defp _make_uuid_filter(filter) do
+    comp_norm = normalize_comp(filter, "=")
+
+    case comp_norm do
+      "=" ->
+        parse_uuid(Map.get(filter, "value"))
+
+      "NULL" ->
+        nil
+
+      "IS_EMPTY" ->
+        nil
+
+      "IS NULL" ->
+        nil
+
+      "NOT_NULL" ->
+        :not_null
+
+      "IS_NOT_EMPTY" ->
+        :not_null
+
+      "IS NOT NULL" ->
+        :not_null
+
+      "IN" ->
+        values =
+          Map.get(filter, "value", "")
+          |> parse_csv_values()
+          |> Enum.map(&parse_uuid/1)
+
+        if values == [], do: raise(ArgumentError, "IN requires at least one value")
+        {:in, values}
+
+      "NOT IN" ->
+        values =
+          Map.get(filter, "value", "")
+          |> parse_csv_values()
+          |> Enum.map(&parse_uuid/1)
+
+        if values == [], do: raise(ArgumentError, "NOT IN requires at least one value")
+        {:not_in, values}
+
+      "!=" ->
+        {"!=", parse_uuid(Map.get(filter, "value"))}
+
+      _ ->
+        raise ArgumentError, "unsupported UUID comparison operator #{inspect(comp_norm)}"
+    end
+  end
+
+  defp parse_uuid(value) when is_binary(value) do
+    cond do
+      byte_size(value) == 16 and Kernel.match?({:ok, _uuid}, Ecto.UUID.load(value)) ->
+        value
+
+      true ->
+        case Ecto.UUID.dump(value) do
+          {:ok, uuid} -> uuid
+          :error -> raise ArgumentError, "invalid UUID #{inspect(value)}"
+        end
+    end
+  end
+
+  defp parse_uuid(value), do: value |> to_string() |> parse_uuid()
+
+  defp uuid_filter?(column, filter, filter_key) do
+    id_like_filter_key?(column, filter_key) and
+      filter
+      |> filter_values()
+      |> Enum.any?(&uuid_string?/1)
+  end
+
+  defp filter_values(filter) do
+    selected_ids =
+      case Map.get(filter, "selected_ids") do
+        ids when is_list(ids) -> ids
+        ids when is_binary(ids) -> String.split(ids, ",")
+        _ -> []
+      end
+
+    selected_ids ++ parse_csv_values(Map.get(filter, "value", ""))
+  end
+
+  defp id_like_filter_key?(column, filter_key) do
+    filter_type = Map.get(column, :filter_type) || Map.get(column, "filter_type")
+
+    filter_type == :multi_select_id or
+      filter_type == "multi_select_id" or
+      id_like_name?(Map.get(column, :field)) or
+      id_like_name?(Map.get(column, :colid)) or
+      id_like_name?(filter_key)
+  end
+
+  defp id_like_name?(nil), do: false
+
+  defp id_like_name?(name) do
+    case to_string(name) do
+      "id" -> true
+      value -> String.ends_with?(value, ".id") or String.ends_with?(value, "_id")
+    end
+  end
+
+  defp uuid_string?(value) when is_binary(value) do
+    Kernel.match?({:ok, _uuid}, Ecto.UUID.cast(String.trim(value)))
+  end
+
+  defp uuid_string?(_value), do: false
 
   defp _make_date_filter(filter, field_conf) do
     comp = Map.get(filter, "comp", "=")
@@ -706,6 +816,12 @@ defmodule SelectoComponents.Helpers.Filters do
 
   # Build filter based on column type
   defp build_typed_filter(selecto, column, f, filter_key) do
+    column =
+      column
+      |> Map.put_new(:field, filter_key)
+      |> Map.put_new(:colid, filter_key)
+      |> then(&SchemaUtils.with_resolved_type(selecto, &1))
+
     date_like_type = Selecto.Temporal.date_like_type(column)
 
     cond do
@@ -740,6 +856,12 @@ defmodule SelectoComponents.Helpers.Filters do
           {:error, reason} -> {:skip, {:invalid_numeric, reason}}
         end
 
+      SchemaUtils.uuid_type?(column.type) ->
+        case safe_make_uuid_filter(f) do
+          {:ok, filter_val} -> {:ok, [{filter_key, filter_val}]}
+          {:error, reason} -> {:skip, {:invalid_uuid, reason}}
+        end
+
       column.type == :tsvector ->
         {:ok, [make_text_search_filter(f)]}
 
@@ -752,6 +874,12 @@ defmodule SelectoComponents.Helpers.Filters do
           end
 
         {:ok, [{filter_key, value}]}
+
+      column.type == :string and uuid_filter?(column, f, filter_key) ->
+        case safe_make_uuid_filter(f) do
+          {:ok, filter_val} -> {:ok, [{filter_key, filter_val}]}
+          {:error, reason} -> {:skip, {:invalid_uuid, reason}}
+        end
 
       column.type == :string ->
         case enum_values_for_filter(selecto, filter_key, column) do
@@ -817,6 +945,12 @@ defmodule SelectoComponents.Helpers.Filters do
   # Safe wrapper for string filter creation
   defp safe_make_string_filter(filter) do
     {:ok, _make_string_filter(filter)}
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp safe_make_uuid_filter(filter) do
+    {:ok, _make_uuid_filter(filter)}
   rescue
     e -> {:error, Exception.message(e)}
   end

--- a/lib/selecto_components/schema_utils.ex
+++ b/lib/selecto_components/schema_utils.ex
@@ -1,0 +1,149 @@
+defmodule SelectoComponents.SchemaUtils do
+  @moduledoc false
+
+  def with_resolved_type(nil, column), do: column
+
+  def with_resolved_type(selecto, %{} = column) do
+    Map.put(column, :type, resolved_type(selecto, column))
+  end
+
+  def with_resolved_type(_selecto, column), do: column
+
+  def resolved_type(nil, %{} = column), do: Map.get(column, :type, :string)
+  def resolved_type(nil, _column), do: :string
+
+  def resolved_type(selecto, %{} = column) do
+    merged_column =
+      case Map.get(column, :colid) do
+        colid when is_binary(colid) or is_atom(colid) ->
+          case Selecto.field(selecto, colid) do
+            nil -> column
+            field_info -> Map.merge(field_info, column)
+          end
+
+        _ ->
+          column
+      end
+
+    case schema_field_type(selecto, merged_column) do
+      nil -> Map.get(merged_column, :type, :string)
+      type -> type
+    end
+  end
+
+  def resolved_type(selecto, field) when is_binary(field) or is_atom(field) do
+    case Selecto.field(selecto, field) do
+      nil ->
+        resolved_type(selecto, field_fallback_metadata(field))
+
+      column ->
+        resolved_type(selecto, column)
+    end
+  end
+
+  def resolved_type(_selecto, _field), do: :string
+
+  def uuid_type?(type), do: normalize_type(type) == :uuid
+
+  defp schema_field_type(selecto, column) do
+    with {:ok, field_atom} <- field_atom(column),
+         {:ok, schema_module} <- schema_module(column, selecto),
+         true <- function_exported?(schema_module, :__schema__, 2),
+         type when not is_nil(type) <- schema_module.__schema__(:type, field_atom) do
+      normalize_type(type)
+    else
+      _ -> nil
+    end
+  end
+
+  defp schema_module(column, selecto) do
+    join_ref =
+      Map.get(column, :requires_join) ||
+        Map.get(column, :source_join) ||
+        inferred_join_ref(column)
+
+    case join_ref do
+      :selecto_root ->
+        module = get_in(Selecto.domain(selecto), [:source, :schema_module])
+        if is_atom(module), do: {:ok, module}, else: :error
+
+      join when is_atom(join) ->
+        module = get_in(Selecto.domain(selecto), [:schemas, join, :schema_module])
+        if is_atom(module), do: {:ok, module}, else: :error
+
+      join when is_binary(join) ->
+        case safe_existing_atom(join) do
+          {:ok, join_atom} -> schema_module(Map.put(column, :requires_join, join_atom), selecto)
+          :error -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp field_atom(column) do
+    column
+    |> field_name()
+    |> safe_existing_atom()
+  end
+
+  defp field_name(column) do
+    Map.get(column, :field) || inferred_field_name(column)
+  end
+
+  defp inferred_field_name(column) do
+    column
+    |> Map.get(:colid)
+    |> case do
+      nil -> nil
+      colid -> colid |> to_string() |> String.split(".") |> List.last()
+    end
+  end
+
+  defp inferred_join_ref(column) do
+    column
+    |> Map.get(:colid)
+    |> case do
+      nil ->
+        nil
+
+      colid ->
+        case String.split(to_string(colid), ".", parts: 2) do
+          [_field_only] -> :selecto_root
+          [join, _field] -> join
+        end
+    end
+  end
+
+  defp field_fallback_metadata(field) do
+    %{field: inferred_field_name(%{colid: field}), colid: field, type: :string}
+  end
+
+  defp safe_existing_atom(value) when is_atom(value), do: {:ok, value}
+
+  defp safe_existing_atom(value) when is_binary(value) do
+    try do
+      {:ok, String.to_existing_atom(value)}
+    rescue
+      ArgumentError -> :error
+    end
+  end
+
+  defp safe_existing_atom(_value), do: :error
+
+  defp normalize_type(type) do
+    type =
+      if function_exported?(Selecto.TypeSystem, :normalize_type, 1) do
+        Selecto.TypeSystem.normalize_type(type)
+      else
+        type
+      end
+
+    case type do
+      :binary_id -> :uuid
+      Ecto.UUID -> :uuid
+      other -> other
+    end
+  end
+end

--- a/lib/selecto_components/schema_utils.ex
+++ b/lib/selecto_components/schema_utils.ex
@@ -15,7 +15,8 @@ defmodule SelectoComponents.SchemaUtils do
   def resolved_type(selecto, %{} = column) do
     merged_column =
       case Map.get(column, :colid) do
-        colid when is_binary(colid) or is_atom(colid) ->
+        colid
+        when (is_binary(colid) and colid != "") or (is_atom(colid) and not is_nil(colid)) ->
           case Selecto.field(selecto, colid) do
             nil -> column
             field_info -> Map.merge(field_info, column)
@@ -31,7 +32,8 @@ defmodule SelectoComponents.SchemaUtils do
     end
   end
 
-  def resolved_type(selecto, field) when is_binary(field) or is_atom(field) do
+  def resolved_type(selecto, field)
+      when (is_binary(field) and field != "") or (is_atom(field) and not is_nil(field)) do
     case Selecto.field(selecto, field) do
       nil ->
         resolved_type(selecto, field_fallback_metadata(field))

--- a/lib/selecto_components/views/aggregate/component.ex
+++ b/lib/selecto_components/views/aggregate/component.ex
@@ -449,33 +449,33 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         filter_attrs: filter_attrs,
         continued?: continued?,
         display_level: display_level,
-        grand_total?: grand_total?
+        grand_total?: grand_total?,
+        active_group_range: active_group_range_for_level(assigns.group_by, display_level),
+        group_blocks: row_group_blocks(assigns.group_by, group_cols)
       )
 
     ~H"""
     <tr style={@row_style}>
-      <%!-- Render group by columns --%>
-      <%= for {{value, {_alias, {:group_by, _field, coldef}}}, idx} <- Enum.zip(@group_cols, @group_by) |> Enum.with_index() do %>
+      <%!-- Render visible group-by blocks --%>
+      <%= for block <- @group_blocks do %>
         <td class={"px-3 py-2 text-sm #{@font_weight}"} style="color: var(--sc-text-primary); border-bottom: 1px solid var(--sc-surface-border);">
-          <div style={"padding-left: #{if idx == 0, do: @indent_px, else: 0}px"}>
-            <%= if @grand_total? and @display_level == 0 and idx == 0 do %>
+          <div style={"padding-left: #{group_block_padding(block, @active_group_range, @indent_px)}px"}>
+            <%= if @grand_total? and @display_level == 0 and block.start_idx == 0 do %>
               <%!-- Grand total row --%>
               <span style="color: var(--sc-text-muted); font-style: italic;">Total</span>
             <% else %>
-              <%!-- Show value only for the rightmost filled/unfilled column at this level --%>
-              <%!-- For level N, show column at index N-1 (0-indexed) --%>
-              <%= if idx == @display_level - 1 do %>
+              <%= if display_group_block?(block, @active_group_range) do %>
                 <%= if @continued? do %>
-                    <span style="color: var(--sc-accent);">
-                      {format_group_value(value, coldef)} (continued)
-                    </span>
+                  <span style="color: var(--sc-accent);">
+                    {group_block_value(block)} (continued)
+                  </span>
                 <% else %>
                   <div
                     phx-click="agg_add_filters"
                     {@filter_attrs}
                     class="cursor-pointer hover:underline"
                   >
-                    {format_group_value(value, coldef)}
+                    {group_block_value(block)}
                   </div>
                 <% end %>
               <% end %>
@@ -698,9 +698,15 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
     # Count the actual group by fields (not the ROLLUP wrapper)
     num_group_by =
-      case rollup_group_by do
-        [{:rollup, positions}] when is_list(positions) -> Enum.count(positions)
-        _ -> 0
+      case Map.get(assigns.selecto.set, :groups, []) do
+        groups when is_list(groups) and groups != [] ->
+          length(groups)
+
+        _ ->
+          case rollup_group_by do
+            [{:rollup, positions}] when is_list(positions) -> Enum.count(positions)
+            _ -> 0
+          end
       end
 
     # num_aggregates = Enum.count(selected_fields) - num_group_by
@@ -992,6 +998,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         paged_rollup_rows: paged_rollup_rows,
         num_group_by: num_group_by,
         group_by: group_by,
+        display_group_headers: display_group_headers(group_by),
         aggregate: aggregates_processed,
         aggregate_server_paged?: server_paged?,
         aggregate_total_rows: aggregate_total_rows,
@@ -1242,7 +1249,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
             <thead style="background: var(--sc-surface-bg-alt);">
               <tr>
                 <%!-- Headers for group by columns --%>
-                <%= for {alias, {:group_by, _field, _coldef}} <- @group_by do %>
+                <%= for alias <- @display_group_headers do %>
                   <th class="px-3 py-3.5 text-left text-sm font-semibold" style="color: var(--sc-text-primary); border-bottom: 1px solid var(--sc-surface-border);">
                     {alias}
                   </th>
@@ -1475,6 +1482,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
   defp composite_group_value?(coldef) do
     join_mode = Map.get(coldef || %{}, :join_mode) || Map.get(coldef || %{}, "join_mode")
+
     group_by_filter_select =
       Map.get(coldef || %{}, :group_by_filter_select) ||
         Map.get(coldef || %{}, "group_by_filter_select")
@@ -1551,12 +1559,131 @@ defmodule SelectoComponents.Views.Aggregate.Component do
       coldef
       |> Map.put(:group_format, format)
       |> Map.put("group_format", format)
+      |> maybe_set_linked_to_next(cfg)
     else
-      coldef
+      maybe_set_linked_to_next(coldef, cfg)
     end
   end
 
   defp maybe_set_group_by_format(coldef, _), do: coldef
+
+  defp maybe_set_linked_to_next(coldef, cfg) when is_map(coldef) and is_map(cfg) do
+    linked? =
+      Map.get(cfg, "linked_to_next", Map.get(cfg, :linked_to_next))
+      |> truthy?()
+
+    coldef
+    |> Map.put(:linked_to_next, linked?)
+    |> Map.put("linked_to_next", linked?)
+  end
+
+  defp maybe_set_linked_to_next(coldef, _cfg), do: coldef
+
+  defp display_group_headers(group_by) when is_list(group_by) do
+    linked_group_ranges(group_by)
+    |> Enum.map(fn {start_idx, end_idx} ->
+      group_by
+      |> Enum.slice(start_idx, end_idx - start_idx + 1)
+      |> Enum.map(fn {alias_name, _definition} -> alias_name end)
+      |> Enum.join(" / ")
+    end)
+  end
+
+  defp display_group_headers(_group_by), do: []
+
+  defp active_group_range_for_level(_group_by, 0), do: nil
+
+  defp active_group_range_for_level(group_by, display_level)
+       when is_list(group_by) and display_level > 0 do
+    display_idx = display_level - 1
+
+    linked_group_ranges(group_by)
+    |> Enum.find(fn {start_idx, end_idx} ->
+      display_idx >= start_idx and display_idx <= end_idx
+    end)
+  end
+
+  defp active_group_range_for_level(_group_by, _display_level), do: nil
+
+  defp linked_group_ranges(group_by) when is_list(group_by) do
+    {ranges, current_start} =
+      Enum.with_index(group_by)
+      |> Enum.reduce({[], nil}, fn {{_alias, {:group_by, _field, coldef}}, idx},
+                                   {ranges, current_start} ->
+        current_start = if is_nil(current_start), do: idx, else: current_start
+
+        if linked_to_next?(coldef) do
+          {ranges, current_start}
+        else
+          {ranges ++ [{current_start, idx}], nil}
+        end
+      end)
+
+    case current_start do
+      nil -> ranges
+      start_idx -> ranges ++ [{start_idx, max(length(group_by) - 1, start_idx)}]
+    end
+  end
+
+  defp linked_group_ranges(_group_by), do: []
+
+  defp linked_to_next?(coldef) when is_map(coldef) do
+    truthy?(Map.get(coldef, :linked_to_next, Map.get(coldef, "linked_to_next")))
+  end
+
+  defp linked_to_next?(_coldef), do: false
+
+  defp row_group_blocks(group_by, group_cols) when is_list(group_by) and is_list(group_cols) do
+    linked_group_ranges(group_by)
+    |> Enum.map(fn {start_idx, end_idx} ->
+      %{
+        start_idx: start_idx,
+        end_idx: end_idx,
+        defs: Enum.slice(group_by, start_idx, end_idx - start_idx + 1),
+        values: Enum.slice(group_cols, start_idx, end_idx - start_idx + 1)
+      }
+    end)
+  end
+
+  defp row_group_blocks(_group_by, _group_cols), do: []
+
+  defp group_block_value(%{defs: defs, values: values}) do
+    formatted_values =
+      values
+      |> Enum.zip(defs)
+      |> Enum.take_while(fn {value, _definition} -> value not in [nil, ""] end)
+      |> Enum.map(fn {value, {_alias, {:group_by, _field, coldef}}} ->
+        format_group_value(value, coldef)
+      end)
+
+    case formatted_values do
+      [] ->
+        case Enum.zip(values, defs) do
+          [{value, {_alias, {:group_by, _field, coldef}}} | _rest] ->
+            format_group_value(value, coldef)
+
+          _ ->
+            ""
+        end
+
+      values_to_join ->
+        Enum.join(values_to_join, " / ")
+    end
+  end
+
+  defp group_block_value(_block), do: ""
+
+  defp display_group_block?(_block, nil), do: false
+
+  defp display_group_block?(%{start_idx: start_idx, end_idx: end_idx}, {active_start, active_end}) do
+    start_idx == active_start and end_idx == active_end
+  end
+
+  defp group_block_padding(%{start_idx: start_idx}, {active_start, _active_end}, indent_px)
+       when start_idx == active_start,
+       do: indent_px
+
+  defp group_block_padding(_block, _active_group_range, _indent_px), do: 0
 
   @impl true
   def handle_event("set_aggregate_page", %{"page" => page_param}, socket) do

--- a/lib/selecto_components/views/aggregate/component.ex
+++ b/lib/selecto_components/views/aggregate/component.ex
@@ -970,8 +970,12 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
     total_pages = if aggregate_total_rows > 0, do: max_page + 1, else: 0
 
+    display_group_axes = visible_group_axes(group_by)
     grid_enabled = truthy?(Map.get(aggregate_meta, :grid_enabled, false))
-    grid_available? = grid_enabled and num_group_by == 2 and length(aggregates_processed) == 1
+
+    grid_available? =
+      grid_enabled and length(display_group_axes) == 2 and length(aggregates_processed) == 1
+
     grid_colorize = truthy?(Map.get(aggregate_meta, :grid_colorize, false))
 
     grid_color_scale =
@@ -986,6 +990,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
             rollup_rows,
             num_group_by,
             group_by,
+            display_group_axes,
             grid_colorize,
             grid_color_scale,
             assigns.theme
@@ -999,6 +1004,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         num_group_by: num_group_by,
         group_by: group_by,
         display_group_headers: display_group_headers(group_by),
+        display_group_axes: display_group_axes,
         aggregate: aggregates_processed,
         aggregate_server_paged?: server_paged?,
         aggregate_total_rows: aggregate_total_rows,
@@ -1165,7 +1171,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         class="mb-3 rounded-md border px-3 py-2 text-sm"
         style="background: color-mix(in srgb, var(--sc-accent-soft) 50%, var(--sc-surface-bg)); border-color: var(--sc-surface-border); color: var(--sc-text-primary);"
       >
-        Grid view requires exactly 2 Group By fields and 1 Aggregate.
+        Grid view requires exactly 2 Group By axes and 1 Aggregate.
       </div>
 
       <%= if @grid_available? and @grid_data do %>
@@ -1207,8 +1213,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
                 </th>
                 <%= for col_value <- @grid_data.col_headers do %>
                   <th class="sticky top-0 z-20 px-3 py-3.5 text-left text-sm font-semibold" style="background: var(--sc-surface-bg-alt); color: var(--sc-text-primary);">
-                    <span class={null_grid_text_class(format_group_value(col_value, @grid_data.col_coldef))}>
-                      {format_group_value(col_value, @grid_data.col_coldef)}
+                    <span class={null_grid_text_class(format_grid_axis_value(col_value, @grid_data.col_axis))}>
+                      {format_grid_axis_value(col_value, @grid_data.col_axis)}
                     </span>
                   </th>
                 <% end %>
@@ -1217,8 +1223,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
             <tbody style="background: var(--sc-surface-bg); border-color: var(--sc-surface-border);">
               <tr :for={row_value <- @grid_data.row_headers}>
                 <td class="sticky left-0 z-10 px-3 py-2 text-sm font-semibold" style="background: var(--sc-surface-bg); color: var(--sc-text-primary); box-shadow: 1px 0 0 0 var(--sc-surface-border);">
-                  <span class={null_grid_text_class(format_group_value(row_value, @grid_data.row_coldef))}>
-                    {format_group_value(row_value, @grid_data.row_coldef)}
+                  <span class={null_grid_text_class(format_grid_axis_value(row_value, @grid_data.row_axis))}>
+                    {format_grid_axis_value(row_value, @grid_data.row_axis)}
                   </span>
                 </td>
           <td
@@ -1228,7 +1234,11 @@ defmodule SelectoComponents.Views.Aggregate.Component do
           >
                   <div
                     phx-click="agg_add_filters"
-                    {build_filter_attrs([row_value, col_value], @group_by, 2)}
+                    {build_filter_attrs(
+                      Map.get(@grid_data.cell_group_cols, {row_value, col_value}, []),
+                      @group_by,
+                      @num_group_by
+                    )}
                     class="cursor-pointer whitespace-nowrap hover:underline"
                   >
                     <span class={null_grid_text_class(format_value(Map.get(@grid_data.cells, {row_value, col_value})))}>
@@ -1286,7 +1296,15 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   defp truthy?(value) when value in [true, "true", "on", "1", 1], do: true
   defp truthy?(_), do: false
 
-  defp build_grid_data(paged_rollup_rows, num_group_by, group_by, colorize?, scale_mode, theme) do
+  defp build_grid_data(
+         paged_rollup_rows,
+         num_group_by,
+         _group_by,
+         display_group_axes,
+         colorize?,
+         scale_mode,
+         theme
+       ) do
     detail_rows =
       Enum.reduce(paged_rollup_rows, [], fn
         {level, row, grand_total?}, acc when level == num_group_by ->
@@ -1308,34 +1326,39 @@ defmodule SelectoComponents.Views.Aggregate.Component do
       end)
       |> Enum.reverse()
 
-    {row_headers, col_headers, cells} =
-      Enum.reduce(detail_rows, {[], [], %{}}, fn row, {row_acc, col_acc, cells_acc} ->
-        row_value = Enum.at(row, 0)
-        col_value = Enum.at(row, 1)
-        agg_value = Enum.at(row, 2)
+    row_axis = Enum.at(display_group_axes, 0, default_grid_axis("Group 1"))
+    col_axis = Enum.at(display_group_axes, 1, default_grid_axis("Group 2"))
+
+    {row_headers, col_headers, cells, cell_group_cols} =
+      Enum.reduce(detail_rows, {[], [], %{}, %{}}, fn row,
+                                                      {row_acc, col_acc, cells_acc,
+                                                       group_cols_acc} ->
+        row_value = grid_axis_value(row, row_axis)
+        col_value = grid_axis_value(row, col_axis)
+        agg_value = Enum.at(row, num_group_by)
+        group_cols = Enum.take(row, num_group_by)
 
         row_acc = if row_value in row_acc, do: row_acc, else: row_acc ++ [row_value]
         col_acc = if col_value in col_acc, do: col_acc, else: col_acc ++ [col_value]
         cells_acc = Map.put(cells_acc, {row_value, col_value}, agg_value)
+        group_cols_acc = Map.put(group_cols_acc, {row_value, col_value}, group_cols)
 
-        {row_acc, col_acc, cells_acc}
+        {row_acc, col_acc, cells_acc, group_cols_acc}
       end)
 
-    row_coldef = grid_coldef(group_by, 0)
-    col_coldef = grid_coldef(group_by, 1)
-
-    row_headers = sort_group_values(row_headers, row_coldef)
-    col_headers = sort_group_values(col_headers, col_coldef)
+    row_headers = sort_grid_axis_values(row_headers, row_axis)
+    col_headers = sort_grid_axis_values(col_headers, col_axis)
     cell_styles = build_grid_cell_styles(cells, colorize?, scale_mode, theme)
 
     %{
-      row_alias: grid_row_alias(group_by),
+      row_alias: row_axis.alias,
       row_headers: row_headers,
       col_headers: col_headers,
       cells: cells,
+      cell_group_cols: cell_group_cols,
       cell_styles: cell_styles,
-      row_coldef: row_coldef,
-      col_coldef: col_coldef
+      row_axis: row_axis,
+      col_axis: col_axis
     }
   end
 
@@ -1423,21 +1446,45 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
   defp numeric_value(_value), do: nil
 
-  defp grid_row_alias([{alias_name, _} | _]) when is_binary(alias_name), do: alias_name
-  defp grid_row_alias(_), do: "Group 1"
-
   defp selected_field_alias({_kind, _field, alias_name}, _fallback)
        when is_binary(alias_name) and alias_name != "",
        do: alias_name
 
   defp selected_field_alias(_selected_field, fallback), do: fallback
 
-  defp grid_coldef(group_by, idx) do
-    case Enum.at(group_by, idx) do
-      {_alias, {:group_by, _field, coldef}} -> coldef
-      _ -> %{}
-    end
+  defp default_grid_axis(alias_name) do
+    %{alias: alias_name, defs: [], start_idx: 0, end_idx: 0}
   end
+
+  defp format_grid_axis_value(value, %{defs: defs}) when is_list(defs) and defs != [] do
+    defs
+    |> Enum.zip(List.wrap(value))
+    |> Enum.map(fn {{_alias, {:group_by, _field, coldef}}, axis_value} ->
+      format_group_value(axis_value, coldef)
+    end)
+    |> Enum.join(" / ")
+  end
+
+  defp format_grid_axis_value(value, _axis), do: format_value(value)
+
+  defp grid_axis_value(row, %{start_idx: start_idx, end_idx: end_idx})
+       when is_list(row) and is_integer(start_idx) and is_integer(end_idx) do
+    Enum.slice(row, start_idx, end_idx - start_idx + 1)
+  end
+
+  defp grid_axis_value(_row, _axis), do: []
+
+  defp sort_grid_axis_values(values, %{defs: [{_alias, {:group_by, _field, coldef}}]}) do
+    values
+    |> Enum.map(fn
+      [value] -> value
+      value -> value
+    end)
+    |> sort_group_values(coldef)
+    |> Enum.map(&List.wrap/1)
+  end
+
+  defp sort_grid_axis_values(values, _axis), do: values
 
   defp format_group_value(value, coldef) do
     display_value = display_value_for_group(value, coldef)
@@ -1580,16 +1627,31 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   defp maybe_set_linked_to_next(coldef, _cfg), do: coldef
 
   defp display_group_headers(group_by) when is_list(group_by) do
-    linked_group_ranges(group_by)
-    |> Enum.map(fn {start_idx, end_idx} ->
-      group_by
-      |> Enum.slice(start_idx, end_idx - start_idx + 1)
-      |> Enum.map(fn {alias_name, _definition} -> alias_name end)
-      |> Enum.join(" / ")
-    end)
+    group_by
+    |> visible_group_axes()
+    |> Enum.map(& &1.alias)
   end
 
   defp display_group_headers(_group_by), do: []
+
+  defp visible_group_axes(group_by) when is_list(group_by) do
+    linked_group_ranges(group_by)
+    |> Enum.map(fn {start_idx, end_idx} ->
+      defs = Enum.slice(group_by, start_idx, end_idx - start_idx + 1)
+
+      %{
+        alias:
+          defs
+          |> Enum.map(fn {alias_name, _definition} -> alias_name end)
+          |> Enum.join(" / "),
+        defs: defs,
+        start_idx: start_idx,
+        end_idx: end_idx
+      }
+    end)
+  end
+
+  defp visible_group_axes(_group_by), do: []
 
   defp active_group_range_for_level(_group_by, 0), do: nil
 

--- a/lib/selecto_components/views/aggregate/component.ex
+++ b/lib/selecto_components/views/aggregate/component.ex
@@ -346,21 +346,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
             end
         end
 
-      # Extract the actual value (handle tuples and NULL)
-      filter_value =
-        case value do
-          # Special marker for IS_EMPTY filter (ROLLUP NULL)
-          nil -> "__NULL__"
-          # Empty string from ROLLUP NULL
-          "" -> "__NULL__"
-          # COALESCE result for data NULL
-          "[NULL]" -> "__NULL__"
-          # COALESCE result in tuple
-          {_display, "[NULL]"} -> "__NULL__"
-          {_display, filter_val} when is_nil(filter_val) or filter_val == "" -> "__NULL__"
-          {_display, filter_val} -> filter_val
-          _ -> value
-        end
+      filter_value = filter_value_for_group(value, field, coldef)
 
       # Use indexed phx-value attributes to support multiple group levels
       # phx-value-field0, phx-value-value0, phx-value-field1, phx-value1, etc.
@@ -1447,10 +1433,53 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   end
 
   defp format_group_value(value, coldef) do
+    display_value = display_value_for_group(value, coldef)
+
     case Map.get(coldef || %{}, :group_format) || Map.get(coldef || %{}, "group_format") do
-      "D" -> weekday_name(value)
-      _ -> format_value(value)
+      "D" -> weekday_name(display_value)
+      _ -> format_value(display_value)
     end
+  end
+
+  defp display_value_for_group(value, coldef) do
+    if composite_group_value?(coldef) do
+      case value do
+        {display_value, _filter_value} -> display_value
+        [display_value, _filter_value] -> display_value
+        _ -> value
+      end
+    else
+      value
+    end
+  end
+
+  defp filter_value_for_group(value, field, coldef) do
+    extracted_value =
+      if composite_group_value?(coldef) or match?({:row, _fields, _alias}, field) do
+        case value do
+          {_display_value, filter_value} -> filter_value
+          [_display_value, filter_value] -> filter_value
+          _ -> value
+        end
+      else
+        value
+      end
+
+    case extracted_value do
+      nil -> "__NULL__"
+      "" -> "__NULL__"
+      "[NULL]" -> "__NULL__"
+      _ -> extracted_value
+    end
+  end
+
+  defp composite_group_value?(coldef) do
+    join_mode = Map.get(coldef || %{}, :join_mode) || Map.get(coldef || %{}, "join_mode")
+    group_by_filter_select =
+      Map.get(coldef || %{}, :group_by_filter_select) ||
+        Map.get(coldef || %{}, "group_by_filter_select")
+
+    join_mode in [:lookup, :star, :tag] or not is_nil(group_by_filter_select)
   end
 
   defp null_grid_text_class("[NULL]"), do: nil

--- a/lib/selecto_components/views/aggregate/form.ex
+++ b/lib/selecto_components/views/aggregate/form.ex
@@ -136,6 +136,46 @@ defmodule SelectoComponents.Views.Aggregate.Form do
             theme={@theme}
           />
         </:item_form>
+        <:between_item :let={{id, _item, config, _index, {next_id, _next_item, _next_config}}}>
+          <% linked? = linked_to_next?(config) %>
+          <% toggle_id = "group-by-link-#{id}-#{next_id}-#{if linked?, do: "on", else: "off"}" %>
+          <label
+            for={toggle_id}
+            class="group flex items-center gap-1.5"
+            title="Link this group-by to the next one"
+            aria-label="Link this group-by to the next one"
+          >
+            <span class="h-px w-4 transition" style="background: var(--sc-surface-border);"></span>
+            <input type="hidden" name={"group_by[#{id}][linked_to_next]"} value="false" />
+            <input
+              id={toggle_id}
+              type="checkbox"
+              name={"group_by[#{id}][linked_to_next]"}
+              value="true"
+              checked={linked?}
+              class="h-3.5 w-3.5 cursor-pointer rounded-full border transition hover:scale-110"
+              style={
+                if linked? do
+                  "border-color: var(--sc-accent); background: var(--sc-accent-soft); accent-color: var(--sc-accent);"
+                else
+                  "border-color: var(--sc-surface-border); background: var(--sc-surface-bg-alt); accent-color: var(--sc-accent);"
+                end
+              }
+            />
+            <span class="sr-only">Link next group-by</span>
+            <span
+              class="h-px w-4 transition"
+              style={
+                if linked? do
+                  "background: color-mix(in srgb, var(--sc-accent) 55%, var(--sc-surface-border));"
+                else
+                  "background: var(--sc-surface-border);"
+                end
+              }
+            >
+            </span>
+          </label>
+        </:between_item>
       </.live_component>
       Aggregates:
       <.live_component
@@ -223,6 +263,13 @@ defmodule SelectoComponents.Views.Aggregate.Form do
 
   defp normalize_checkbox(value) when value in [true, "true", "on", "1", 1], do: true
   defp normalize_checkbox(_value), do: false
+
+  defp linked_to_next?(config) when is_map(config) do
+    value = Map.get(config, "linked_to_next", Map.get(config, :linked_to_next))
+    normalize_checkbox(value)
+  end
+
+  defp linked_to_next?(_config), do: false
 
   defp column_display_name(columns, item, col) do
     item_str =

--- a/lib/selecto_components/views/aggregate/process.ex
+++ b/lib/selecto_components/views/aggregate/process.ex
@@ -83,7 +83,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
       end
 
     rollup_group_by =
-      case Enum.map(group_by_with_coalesce, fn {_col, sel} -> sel end) do
+      case collapse_linked_rollup_groups(group_by_with_coalesce) do
         [] -> []
         selectors -> [{:rollup, selectors}]
       end
@@ -110,6 +110,33 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
   defp truthy_param?(value) when value in [true, "true", "on", "1", 1], do: true
   defp truthy_param?(_), do: false
+
+  defp collapse_linked_rollup_groups(group_by_with_coalesce) do
+    {groups, current_group} =
+      Enum.reduce(group_by_with_coalesce, {[], []}, fn {col, sel}, {groups, current_group} ->
+        current_group = current_group ++ [sel]
+
+        if linked_to_next?(col) do
+          {groups, current_group}
+        else
+          {groups ++ [finalize_rollup_group(current_group)], []}
+        end
+      end)
+
+    groups ++ finalize_trailing_rollup_group(current_group)
+  end
+
+  defp finalize_rollup_group([selector]), do: selector
+  defp finalize_rollup_group(selectors), do: {:grouping_set, selectors}
+
+  defp finalize_trailing_rollup_group([]), do: []
+  defp finalize_trailing_rollup_group(current_group), do: [finalize_rollup_group(current_group)]
+
+  defp linked_to_next?(col) when is_map(col) do
+    truthy_param?(Map.get(col, :linked_to_next, Map.get(col, "linked_to_next")))
+  end
+
+  defp linked_to_next?(_col), do: false
 
   def group_by(group_by, columns, selecto) do
     group_by
@@ -160,6 +187,8 @@ defmodule SelectoComponents.Views.Aggregate.Process do
           col
           |> Map.put(:group_format, Map.get(e, "format"))
           |> Map.put("group_format", Map.get(e, "format"))
+          |> Map.put(:linked_to_next, truthy_param?(Map.get(e, "linked_to_next")))
+          |> Map.put("linked_to_next", truthy_param?(Map.get(e, "linked_to_next")))
         else
           col
         end
@@ -332,6 +361,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
     text_type and not enum_by_name and not root_enum and not enum_by_metadata and not id_like
   end
 
+  defp resolve_column_metadata(col, nil), do: col
   defp resolve_column_metadata(col, selecto) do
     SchemaUtils.with_resolved_type(selecto, col)
   end
@@ -353,6 +383,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
   defp enum_field_by_metadata?(_, _), do: false
 
+  defp enum_field_by_colid?(_col, nil), do: false
   defp enum_field_by_colid?(%{colid: colid}, selecto) when is_binary(colid) or is_atom(colid) do
     case Selecto.field(selecto, colid) do
       nil -> false
@@ -362,6 +393,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
   defp enum_field_by_colid?(_, _), do: false
 
+  defp root_enum_field?(_col, nil), do: false
   defp root_enum_field?(%{field: field, requires_join: :selecto_root}, selecto) do
     with {:ok, field_atom} <- to_existing_atom_safe(field),
          module when is_atom(module) <- get_in(Selecto.domain(selecto), [:source, :schema_module]),
@@ -384,6 +416,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
     end
   end
 
+  defp enum_field_name_any_schema?(_field, nil), do: false
   defp enum_field_name_any_schema?(field, selecto) do
     with {:ok, field_atom} <- to_existing_atom_safe(field) do
       domain = Selecto.domain(selecto)

--- a/lib/selecto_components/views/aggregate/process.ex
+++ b/lib/selecto_components/views/aggregate/process.ex
@@ -1,5 +1,6 @@
 defmodule SelectoComponents.Views.Aggregate.Process do
   alias SelectoComponents.Helpers.BucketParser
+  alias SelectoComponents.SchemaUtils
   alias SelectoComponents.SafeAtom
   alias SelectoComponents.Views.Aggregate.Options
 
@@ -163,6 +164,13 @@ defmodule SelectoComponents.Views.Aggregate.Process do
           col
         end
 
+      col =
+        if is_map(col) and selecto do
+          SchemaUtils.with_resolved_type(selecto, col)
+        else
+          col
+        end
+
       # ????
       alias =
         case Map.get(e, "alias") do
@@ -308,22 +316,24 @@ defmodule SelectoComponents.Views.Aggregate.Process do
   defp should_coalesce_field?(col, selecto) do
     resolved_col = resolve_column_metadata(col, selecto)
     field_name = Map.get(resolved_col, :field) || Map.get(col, :field)
+    colid = Map.get(resolved_col, :colid) || Map.get(col, :colid)
     text_type = text_type?(Map.get(resolved_col, :type))
     enum_by_name = enum_field_name_any_schema?(field_name, selecto)
     root_enum = root_enum_field?(col, selecto)
     enum_by_metadata = enum_field?(resolved_col, selecto)
+    filter_type = Map.get(resolved_col, :filter_type) || Map.get(resolved_col, "filter_type")
 
-    text_type and not enum_by_name and not root_enum and not enum_by_metadata
+    id_like =
+      filter_type == :multi_select_id or
+        filter_type == "multi_select_id" or
+        id_like_name?(field_name) or
+        id_like_name?(colid)
+
+    text_type and not enum_by_name and not root_enum and not enum_by_metadata and not id_like
   end
 
   defp resolve_column_metadata(col, selecto) do
-    colid = Map.get(col, :colid)
-
-    if is_binary(colid) or is_atom(colid) do
-      Selecto.field(selecto, colid) || col
-    else
-      col
-    end
+    SchemaUtils.with_resolved_type(selecto, col)
   end
 
   defp enum_field?(col, selecto) do
@@ -364,6 +374,15 @@ defmodule SelectoComponents.Views.Aggregate.Process do
   end
 
   defp root_enum_field?(_, _), do: false
+
+  defp id_like_name?(nil), do: false
+
+  defp id_like_name?(name) do
+    case to_string(name) do
+      "id" -> true
+      value -> String.ends_with?(value, ".id") or String.ends_with?(value, "_id")
+    end
+  end
 
   defp enum_field_name_any_schema?(field, selecto) do
     with {:ok, field_atom} <- to_existing_atom_safe(field) do

--- a/lib/selecto_components/views/aggregate/process.ex
+++ b/lib/selecto_components/views/aggregate/process.ex
@@ -496,7 +496,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
         case_sql =
           BucketParser.generate_bucket_case_sql(
-            "EXTRACT(DAY FROM AGE(CURRENT_DATE, #{field_with_alias}))",
+            "(CURRENT_DATE - DATE(#{field_with_alias}))",
             bucket_ranges,
             :integer
           )

--- a/lib/selecto_components/views/aggregate/process.ex
+++ b/lib/selecto_components/views/aggregate/process.ex
@@ -362,6 +362,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
   end
 
   defp resolve_column_metadata(col, nil), do: col
+
   defp resolve_column_metadata(col, selecto) do
     SchemaUtils.with_resolved_type(selecto, col)
   end
@@ -384,6 +385,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
   defp enum_field_by_metadata?(_, _), do: false
 
   defp enum_field_by_colid?(_col, nil), do: false
+
   defp enum_field_by_colid?(%{colid: colid}, selecto) when is_binary(colid) or is_atom(colid) do
     case Selecto.field(selecto, colid) do
       nil -> false
@@ -394,6 +396,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
   defp enum_field_by_colid?(_, _), do: false
 
   defp root_enum_field?(_col, nil), do: false
+
   defp root_enum_field?(%{field: field, requires_join: :selecto_root}, selecto) do
     with {:ok, field_atom} <- to_existing_atom_safe(field),
          module when is_atom(module) <- get_in(Selecto.domain(selecto), [:source, :schema_module]),
@@ -417,6 +420,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
   end
 
   defp enum_field_name_any_schema?(_field, nil), do: false
+
   defp enum_field_name_any_schema?(field, selecto) do
     with {:ok, field_atom} <- to_existing_atom_safe(field) do
       domain = Selecto.domain(selecto)

--- a/lib/selecto_components/views/detail/process.ex
+++ b/lib/selecto_components/views/detail/process.ex
@@ -382,7 +382,7 @@ defmodule SelectoComponents.Views.Detail.Process do
 
         case_sql =
           BucketParser.generate_bucket_case_sql(
-            "EXTRACT(DAY FROM AGE(CURRENT_DATE, #{field_with_alias}))",
+            "(CURRENT_DATE - DATE(#{field_with_alias}))",
             bucket_ranges,
             :integer
           )

--- a/lib/selecto_components/views/graph/component.ex
+++ b/lib/selecto_components/views/graph/component.ex
@@ -209,6 +209,24 @@ defmodule SelectoComponents.Views.Graph.Component do
                       const dataset = chartData.datasets[datasetIndex];
                       const value = dataset.data[index];
                       const label = chartData.labels[index];
+                      const drillSpecs = Array.isArray(dataset.drillDown) ? dataset.drillDown[index] : [];
+
+                      const indexedPayload = Array.isArray(drillSpecs)
+                        ? drillSpecs.reduce((acc, spec, specIndex) => {
+                            if (!spec || !spec.field) {
+                              return acc;
+                            }
+
+                            acc[`field${specIndex}`] = spec.field;
+                            acc[`value${specIndex}`] = spec.value;
+
+                            if (spec.gidx !== undefined && spec.gidx !== null) {
+                              acc[`gidx${specIndex}`] = String(spec.gidx);
+                            }
+
+                            return acc;
+                          }, {})
+                        : {};
 
                       const xFieldName = this.el.dataset.xAxis;
                       const yFieldName = dataset.label;
@@ -218,7 +236,8 @@ defmodule SelectoComponents.Views.Graph.Component do
                         value: value,
                         dataset_label: dataset.label,
                         x_field: xFieldName,
-                        y_field: yFieldName
+                        y_field: yFieldName,
+                        ...indexedPayload
                       });
                     }
                   }
@@ -288,56 +307,8 @@ defmodule SelectoComponents.Views.Graph.Component do
     end
   end
 
-  defp prepare_bar_data(results, _aliases, _x_axis_groups, metric_defs, series_groups, chart_type) do
-    # Simplified for now
-    num_x_fields = 1
-    num_series_fields = Enum.count(series_groups)
-
-    # Simple case: single X-axis, single or multiple Y-axis, no series
-    if num_series_fields == 0 do
-      labels = results |> Enum.map(fn row -> format_chart_label(Enum.at(row, 0)) end)
-
-      datasets =
-        metric_defs
-        |> Enum.with_index()
-        |> Enum.map(fn {metric_def, index} ->
-          data =
-            results
-            |> Enum.map(fn row ->
-              value = Enum.at(row, num_x_fields + index)
-              format_numeric_value(value)
-            end)
-
-          series_type = dataset_type(metric_def, chart_type)
-
-          dataset = %{
-            label: metric_def.alias,
-            data: data,
-            yAxisID: axis_id(metric_def),
-            borderColor: metric_color(metric_def, index, 1.0),
-            borderWidth: 2
-          }
-
-          case series_type do
-            "line" ->
-              dataset
-              |> Map.put(:type, "line")
-              |> Map.put(:backgroundColor, metric_color(metric_def, index, 0.15))
-              |> Map.put(:fill, false)
-              |> Map.put(:tension, 0.35)
-
-            _ ->
-              dataset
-              |> Map.put(:type, "bar")
-              |> Map.put(:backgroundColor, metric_color(metric_def, index, 0.7))
-          end
-        end)
-
-      %{labels: labels, datasets: datasets}
-    else
-      # More complex cases would be handled here
-      %{labels: ["No Data"], datasets: [%{data: [0]}]}
-    end
+  defp prepare_bar_data(results, _aliases, x_axis_groups, metric_defs, series_groups, chart_type) do
+    prepare_cartesian_data(results, x_axis_groups, metric_defs, series_groups, chart_type)
   end
 
   defp prepare_line_data(
@@ -348,115 +319,7 @@ defmodule SelectoComponents.Views.Graph.Component do
          series_groups,
          chart_type
        ) do
-    num_x_fields = max(Enum.count(x_axis_groups), 1)
-    num_series_fields = Enum.count(series_groups)
-
-    filtered_results =
-      results
-      |> filter_rollup_rows(num_x_fields, num_series_fields)
-      |> case do
-        [] -> results
-        rows -> rows
-      end
-
-    if num_series_fields == 0 do
-      labels = Enum.map(filtered_results, &x_label(&1, num_x_fields))
-
-      datasets =
-        metric_defs
-        |> Enum.with_index()
-        |> Enum.map(fn {metric_def, index} ->
-          data =
-            Enum.map(filtered_results, fn row ->
-              value = Enum.at(row, num_x_fields + index)
-              format_numeric_value(value)
-            end)
-
-          series_type = dataset_type(metric_def, chart_type)
-
-          dataset = %{
-            label: metric_def.alias,
-            data: data,
-            yAxisID: axis_id(metric_def),
-            borderColor: metric_color(metric_def, index, 1.0),
-            borderWidth: 2
-          }
-
-          case series_type do
-            "bar" ->
-              dataset
-              |> Map.put(:type, "bar")
-              |> Map.put(:backgroundColor, metric_color(metric_def, index, 0.7))
-
-            _ ->
-              dataset
-              |> Map.put(:type, "line")
-              |> Map.put(:backgroundColor, metric_color(metric_def, index, 0.1))
-              |> Map.put(:fill, false)
-              |> Map.put(:tension, 0.4)
-          end
-        end)
-
-      %{labels: labels, datasets: datasets}
-    else
-      labels =
-        filtered_results
-        |> Enum.map(&x_label(&1, num_x_fields))
-        |> Enum.uniq()
-
-      series_keys =
-        filtered_results
-        |> Enum.map(&series_key(&1, num_x_fields, num_series_fields))
-        |> Enum.uniq()
-
-      datasets =
-        metric_defs
-        |> Enum.with_index()
-        |> Enum.flat_map(fn {metric_def, metric_index} ->
-          series_keys
-          |> Enum.with_index()
-          |> Enum.map(fn {series_key, series_index} ->
-            rows_for_series =
-              Enum.filter(filtered_results, fn row ->
-                series_key(row, num_x_fields, num_series_fields) == series_key
-              end)
-
-            values_by_label =
-              Map.new(rows_for_series, fn row ->
-                value = Enum.at(row, num_x_fields + num_series_fields + metric_index)
-                {x_label(row, num_x_fields), format_numeric_value(value)}
-              end)
-
-            data = Enum.map(labels, &Map.get(values_by_label, &1, nil))
-            series_type = dataset_type(metric_def, chart_type)
-            dataset_offset = metric_index * max(length(series_keys), 1) + series_index
-
-            dataset = %{
-              label: "#{metric_def.alias} - #{format_series_key(series_key)}",
-              data: data,
-              yAxisID: axis_id(metric_def),
-              borderColor: metric_color(metric_def, dataset_offset, 1.0),
-              borderWidth: 2
-            }
-
-            case series_type do
-              "bar" ->
-                dataset
-                |> Map.put(:type, "bar")
-                |> Map.put(:backgroundColor, metric_color(metric_def, dataset_offset, 0.7))
-
-              _ ->
-                dataset
-                |> Map.put(:type, "line")
-                |> Map.put(:backgroundColor, metric_color(metric_def, dataset_offset, 0.1))
-                |> Map.put(:fill, false)
-                |> Map.put(:tension, 0.4)
-            end
-          end)
-        end)
-
-      %{labels: labels, datasets: datasets}
-    end
+    prepare_cartesian_data(results, x_axis_groups, metric_defs, series_groups, chart_type)
   end
 
   defp filter_rollup_rows(results, num_x_fields, num_series_fields) do
@@ -468,32 +331,32 @@ defmodule SelectoComponents.Views.Graph.Component do
     end)
   end
 
-  defp x_label(row, num_x_fields) do
-    row
-    |> Enum.take(num_x_fields)
-    |> Enum.map(&format_chart_label/1)
-    |> Enum.join(" / ")
-  end
+  defp prepare_pie_data(results, _aliases, x_axis_groups, _metric_defs) do
+    num_x_fields = max(Enum.count(x_axis_groups), 1)
+    x_defs = build_group_defs(x_axis_groups, 0)
 
-  defp series_key(row, num_x_fields, num_series_fields) do
-    Enum.slice(row, num_x_fields, num_series_fields)
-  end
+    labels =
+      Enum.map(results, fn row ->
+        row
+        |> Enum.take(num_x_fields)
+        |> axis_label(x_defs)
+      end)
 
-  defp format_series_key(series_key) when is_list(series_key) do
-    series_key
-    |> Enum.map(&format_chart_label/1)
-    |> Enum.join(" / ")
-  end
+    data = Enum.map(results, fn row -> format_numeric_value(Enum.at(row, num_x_fields)) end)
 
-  defp prepare_pie_data(results, _aliases, _x_axis_groups, _metric_defs) do
-    labels = results |> Enum.map(fn row -> format_chart_label(Enum.at(row, 0)) end)
-    data = results |> Enum.map(fn row -> format_numeric_value(Enum.at(row, 1)) end)
+    drill_down =
+      Enum.map(results, fn row ->
+        row
+        |> Enum.take(num_x_fields)
+        |> drill_down_specs(x_defs)
+      end)
 
     %{
       labels: labels,
       datasets: [
         %{
           data: data,
+          drillDown: drill_down,
           backgroundColor:
             Enum.with_index(labels) |> Enum.map(fn {_, i} -> generate_color(i, 0.8) end),
           borderColor:
@@ -503,6 +366,323 @@ defmodule SelectoComponents.Views.Graph.Component do
       ]
     }
   end
+
+  defp prepare_cartesian_data(results, x_axis_groups, metric_defs, series_groups, chart_type) do
+    num_x_fields = max(Enum.count(x_axis_groups), 1)
+    num_series_fields = Enum.count(series_groups)
+    x_defs = build_group_defs(x_axis_groups, 0)
+    series_defs = build_group_defs(series_groups, length(x_defs))
+
+    filtered_results =
+      results
+      |> filter_rollup_rows(num_x_fields, num_series_fields)
+      |> case do
+        [] -> results
+        rows -> rows
+      end
+
+    if num_series_fields == 0 do
+      labels =
+        Enum.map(filtered_results, fn row ->
+          row
+          |> Enum.take(num_x_fields)
+          |> axis_label(x_defs)
+        end)
+
+      drill_down =
+        Enum.map(filtered_results, fn row ->
+          row
+          |> Enum.take(num_x_fields)
+          |> drill_down_specs(x_defs)
+        end)
+
+      datasets =
+        metric_defs
+        |> Enum.with_index()
+        |> Enum.map(fn {metric_def, index} ->
+          data =
+            Enum.map(filtered_results, fn row ->
+              value = Enum.at(row, num_x_fields + index)
+              format_numeric_value(value)
+            end)
+
+          build_cartesian_dataset(metric_def, chart_type, index, data, metric_def.alias, drill_down)
+        end)
+
+      %{labels: labels, datasets: datasets}
+    else
+      labels =
+        filtered_results
+        |> Enum.map(fn row ->
+          row
+          |> Enum.take(num_x_fields)
+          |> axis_label(x_defs)
+        end)
+        |> Enum.uniq()
+
+      series_labels =
+        filtered_results
+        |> Enum.map(fn row ->
+          row
+          |> Enum.slice(num_x_fields, num_series_fields)
+          |> axis_label(series_defs)
+        end)
+        |> Enum.uniq()
+
+      datasets =
+        metric_defs
+        |> Enum.with_index()
+        |> Enum.flat_map(fn {metric_def, metric_index} ->
+          series_labels
+          |> Enum.with_index()
+          |> Enum.map(fn {series_label, series_index} ->
+            rows_for_series =
+              Enum.filter(filtered_results, fn row ->
+                row
+                |> Enum.slice(num_x_fields, num_series_fields)
+                |> axis_label(series_defs) == series_label
+              end)
+
+            rows_by_label =
+              Map.new(rows_for_series, fn row ->
+                label =
+                  row
+                  |> Enum.take(num_x_fields)
+                  |> axis_label(x_defs)
+
+                {label, row}
+              end)
+
+            data =
+              Enum.map(labels, fn label ->
+                case Map.get(rows_by_label, label) do
+                  nil ->
+                    nil
+
+                  row ->
+                    row
+                    |> Enum.at(num_x_fields + num_series_fields + metric_index)
+                    |> format_numeric_value()
+                end
+              end)
+
+            drill_down =
+              Enum.map(labels, fn label ->
+                case Map.get(rows_by_label, label) do
+                  nil ->
+                    []
+
+                  row ->
+                    x_specs =
+                      row
+                      |> Enum.take(num_x_fields)
+                      |> drill_down_specs(x_defs)
+
+                    series_specs =
+                      row
+                      |> Enum.slice(num_x_fields, num_series_fields)
+                      |> drill_down_specs(series_defs)
+
+                    x_specs ++ series_specs
+                end
+              end)
+
+            dataset_offset = metric_index * max(length(series_labels), 1) + series_index
+            dataset_label = "#{metric_def.alias} - #{series_label}"
+
+            build_cartesian_dataset(
+              metric_def,
+              chart_type,
+              dataset_offset,
+              data,
+              dataset_label,
+              drill_down
+            )
+          end)
+        end)
+
+      %{labels: labels, datasets: datasets}
+    end
+  end
+
+  defp build_cartesian_dataset(metric_def, chart_type, color_index, data, label, drill_down) do
+    series_type = dataset_type(metric_def, chart_type)
+
+    dataset = %{
+      label: label,
+      data: data,
+      drillDown: drill_down,
+      yAxisID: axis_id(metric_def),
+      borderColor: metric_color(metric_def, color_index, 1.0),
+      borderWidth: 2
+    }
+
+    case series_type do
+      "bar" ->
+        dataset
+        |> Map.put(:type, "bar")
+        |> Map.put(:backgroundColor, metric_color(metric_def, color_index, 0.7))
+
+      _ ->
+        dataset
+        |> Map.put(:type, "line")
+        |> Map.put(:backgroundColor, metric_color(metric_def, color_index, 0.1))
+        |> Map.put(:fill, false)
+        |> Map.put(:tension, if(chart_type == "bar", do: 0.35, else: 0.4))
+    end
+  end
+
+  defp build_group_defs(groups, start_index) when is_list(groups) do
+    groups
+    |> Enum.with_index(start_index)
+    |> Enum.map(fn {{col, selector}, group_index} ->
+      %{
+        alias: group_alias(selector),
+        col: col,
+        selector: selector,
+        linked_to_next: linked_to_next?(col),
+        group_index: Integer.to_string(group_index)
+      }
+    end)
+  end
+
+  defp build_group_defs(_groups, _start_index), do: []
+
+  defp group_alias({:field, _field, alias_name}) when is_binary(alias_name) and alias_name != "",
+    do: alias_name
+
+  defp group_alias({_kind, _field, alias_name}) when is_binary(alias_name) and alias_name != "",
+    do: alias_name
+
+  defp group_alias(_), do: "Group"
+
+  defp axis_label(values, group_defs) when is_list(values) and is_list(group_defs) do
+    values
+    |> axis_value_blocks(group_defs)
+    |> Enum.map(& &1.display)
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.join(" • ")
+  end
+
+  defp axis_label(values, _group_defs) when is_list(values) do
+    values
+    |> Enum.map(&format_chart_label/1)
+    |> Enum.join(" / ")
+  end
+
+  defp axis_label(_values, _group_defs), do: ""
+
+  defp axis_value_blocks(values, group_defs) when is_list(values) and is_list(group_defs) do
+    linked_group_ranges(group_defs)
+    |> Enum.map(fn {start_idx, end_idx} ->
+      defs = Enum.slice(group_defs, start_idx, end_idx - start_idx + 1)
+      block_values = Enum.slice(values, start_idx, end_idx - start_idx + 1)
+
+      %{
+        defs: defs,
+        values: block_values,
+        display:
+          block_values
+          |> Enum.map(&display_value_for_group/1)
+          |> Enum.join(" / ")
+      }
+    end)
+  end
+
+  defp axis_value_blocks(_values, _group_defs), do: []
+
+  defp drill_down_specs(values, group_defs) when is_list(values) and is_list(group_defs) do
+    Enum.zip(group_defs, values)
+    |> Enum.map(fn {group_def, value} ->
+      %{
+        field: filter_field_name(group_def),
+        value: filter_value_for_group(value, group_def),
+        gidx: group_def.group_index
+      }
+    end)
+  end
+
+  defp drill_down_specs(_values, _group_defs), do: []
+
+  defp filter_field_name(%{col: %{} = col}) do
+    col
+    |> Map.get(:group_by_filter, Map.get(col, :colid))
+    |> to_string()
+  end
+
+  defp filter_field_name(%{selector: {:field, field_name, _alias}}) when is_binary(field_name),
+    do: field_name
+
+  defp filter_field_name(%{selector: {:field, field_name, _alias}}) when is_atom(field_name),
+    do: Atom.to_string(field_name)
+
+  defp filter_field_name(_), do: ""
+
+  defp display_value_for_group(value) do
+    case value do
+      {display_value, _filter_value} -> format_chart_label(display_value)
+      [display_value, _filter_value] -> format_chart_label(display_value)
+      _ -> format_chart_label(value)
+    end
+  end
+
+  defp filter_value_for_group(value, %{col: col, selector: selector}) do
+    extracted_value =
+      if composite_group_value?(col) or match?({:row, _fields, _alias}, selector) do
+        case value do
+          {_display_value, filter_value} -> filter_value
+          [display_value, filter_value] when not is_list(display_value) -> filter_value
+          _ -> value
+        end
+      else
+        value
+      end
+
+    case extracted_value do
+      nil -> "__NULL__"
+      "" -> "__NULL__"
+      "[NULL]" -> "__NULL__"
+      _ -> extracted_value
+    end
+  end
+
+  defp composite_group_value?(coldef) when is_map(coldef) do
+    join_mode = Map.get(coldef, :join_mode) || Map.get(coldef, "join_mode")
+
+    group_by_filter_select =
+      Map.get(coldef, :group_by_filter_select) || Map.get(coldef, "group_by_filter_select")
+
+    join_mode in [:lookup, :star, :tag] or not is_nil(group_by_filter_select)
+  end
+
+  defp composite_group_value?(_coldef), do: false
+
+  defp linked_group_ranges(group_defs) when is_list(group_defs) do
+    {ranges, current_start} =
+      Enum.with_index(group_defs)
+      |> Enum.reduce({[], nil}, fn {group_def, idx}, {ranges, current_start} ->
+        current_start = if is_nil(current_start), do: idx, else: current_start
+
+        if group_def.linked_to_next do
+          {ranges, current_start}
+        else
+          {ranges ++ [{current_start, idx}], nil}
+        end
+      end)
+
+    case current_start do
+      nil -> ranges
+      start_idx -> ranges ++ [{start_idx, max(length(group_defs) - 1, start_idx)}]
+    end
+  end
+
+  defp linked_group_ranges(_group_defs), do: []
+
+  defp linked_to_next?(coldef) when is_map(coldef) do
+    Map.get(coldef, :linked_to_next, Map.get(coldef, "linked_to_next")) in [true, "true", "on", "1", 1]
+  end
+
+  defp linked_to_next?(_coldef), do: false
 
   defp prepare_scatter_data(
          _results,

--- a/lib/selecto_components/views/graph/component.ex
+++ b/lib/selecto_components/views/graph/component.ex
@@ -406,7 +406,14 @@ defmodule SelectoComponents.Views.Graph.Component do
               format_numeric_value(value)
             end)
 
-          build_cartesian_dataset(metric_def, chart_type, index, data, metric_def.alias, drill_down)
+          build_cartesian_dataset(
+            metric_def,
+            chart_type,
+            index,
+            data,
+            metric_def.alias,
+            drill_down
+          )
         end)
 
       %{labels: labels, datasets: datasets}
@@ -679,7 +686,13 @@ defmodule SelectoComponents.Views.Graph.Component do
   defp linked_group_ranges(_group_defs), do: []
 
   defp linked_to_next?(coldef) when is_map(coldef) do
-    Map.get(coldef, :linked_to_next, Map.get(coldef, "linked_to_next")) in [true, "true", "on", "1", 1]
+    Map.get(coldef, :linked_to_next, Map.get(coldef, "linked_to_next")) in [
+      true,
+      "true",
+      "on",
+      "1",
+      1
+    ]
   end
 
   defp linked_to_next?(_coldef), do: false

--- a/lib/selecto_components/views/graph/drill_down.ex
+++ b/lib/selecto_components/views/graph/drill_down.ex
@@ -1,12 +1,56 @@
 defmodule SelectoComponents.Views.Graph.DrillDown do
   @moduledoc false
 
+  alias SelectoComponents.Form.DrillDownFilters
   alias SelectoComponents.Form.ParamsState
   alias SelectoComponents.SafeAtom
 
   @drill_down_error_message "Could not drill down for that chart value. Try a different slice or bar."
 
   def apply(socket, params) do
+    if indexed_drill_down?(params) do
+      apply_indexed_drill_down(socket, params)
+    else
+      apply_single_label_drill_down(socket, params)
+    end
+  end
+
+  defp apply_indexed_drill_down(socket, params) do
+    current_view_mode = socket.assigns.view_config.view_mode
+    new_view_mode = determine_drill_down_view(socket, current_view_mode)
+
+    view_params =
+      DrillDownFilters.build_agg_drill_down_params(params, socket)
+      |> Map.put("view_mode", normalize_view_mode_param(new_view_mode))
+
+    filter_tuples = DrillDownFilters.build_filter_tuples(params, socket)
+    clicked_fields = clicked_filter_fields(filter_tuples)
+
+    updated_filters =
+      Enum.filter(socket.assigns.view_config.filters, fn
+        {_id, "filters", %{} = filter} ->
+          not MapSet.member?(clicked_fields, Map.get(filter, "filter"))
+
+        [_, "filters", %{} = filter] ->
+          not MapSet.member?(clicked_fields, Map.get(filter, "filter"))
+
+        _ ->
+          true
+      end) ++ filter_tuples
+
+    updated_socket =
+      socket
+      |> Phoenix.Component.assign(
+        :view_config,
+        %{socket.assigns.view_config | view_mode: new_view_mode, filters: updated_filters}
+      )
+
+    updated_socket = ParamsState.view_from_params(view_params, updated_socket)
+
+    {:ok, updated_socket, view_params}
+  end
+
+  defp apply_single_label_drill_down(socket, params) do
     label = Map.get(params, "label")
     graph_config = current_graph_config(socket)
 
@@ -48,6 +92,12 @@ defmodule SelectoComponents.Views.Graph.DrillDown do
     end
   end
 
+  defp indexed_drill_down?(params) when is_map(params) do
+    Enum.any?(Map.keys(params), &String.starts_with?(&1, "field"))
+  end
+
+  defp indexed_drill_down?(_params), do: false
+
   defp determine_drill_down_view(socket, current_view_mode) do
     selected_view = SafeAtom.to_view_mode(current_view_mode)
 
@@ -61,6 +111,26 @@ defmodule SelectoComponents.Views.Graph.DrillDown do
   defp normalize_view_mode_param(view_mode) when is_atom(view_mode), do: Atom.to_string(view_mode)
   defp normalize_view_mode_param(view_mode) when is_binary(view_mode), do: view_mode
   defp normalize_view_mode_param(_view_mode), do: "detail"
+
+  defp clicked_filter_fields(filter_tuples) do
+    filter_tuples
+    |> Enum.reduce(MapSet.new(), fn
+      {_uuid, "filters", %{} = filter}, acc ->
+        case Map.get(filter, "filter") do
+          nil -> acc
+          field_name -> MapSet.put(acc, field_name)
+        end
+
+      [_, "filters", %{} = filter], acc ->
+        case Map.get(filter, "filter") do
+          nil -> acc
+          field_name -> MapSet.put(acc, field_name)
+        end
+
+      _, acc ->
+        acc
+    end)
+  end
 
   defp current_graph_config(socket) do
     selected_view = SafeAtom.to_view_mode(socket.assigns.view_config.view_mode)

--- a/lib/selecto_components/views/graph/form.ex
+++ b/lib/selecto_components/views/graph/form.ex
@@ -67,6 +67,46 @@ defmodule SelectoComponents.Views.Graph.Form do
               theme={@theme}
             />
           </:item_form>
+          <:between_item :let={{id, _item, config, _index, {next_id, _next_item, _next_config}}}>
+            <% linked? = linked_to_next?(config) %>
+            <% toggle_id = "graph-x-axis-link-#{id}-#{next_id}-#{if linked?, do: "on", else: "off"}" %>
+            <label
+              for={toggle_id}
+              class="group flex items-center gap-1.5"
+              title="Link this category field to the next one"
+              aria-label="Link this category field to the next one"
+            >
+              <span class="h-px w-4 transition" style="background: var(--sc-surface-border);"></span>
+              <input type="hidden" name={"x_axis[#{id}][linked_to_next]"} value="false" />
+              <input
+                id={toggle_id}
+                type="checkbox"
+                name={"x_axis[#{id}][linked_to_next]"}
+                value="true"
+                checked={linked?}
+                class="h-3.5 w-3.5 cursor-pointer rounded-full border transition hover:scale-110"
+                style={
+                  if linked? do
+                    "border-color: var(--sc-accent); background: var(--sc-accent-soft); accent-color: var(--sc-accent);"
+                  else
+                    "border-color: var(--sc-surface-border); background: var(--sc-surface-bg-alt); accent-color: var(--sc-accent);"
+                  end
+                }
+              />
+              <span class="sr-only">Link next category field</span>
+              <span
+                class="h-px w-4 transition"
+                style={
+                  if linked? do
+                    "background: color-mix(in srgb, var(--sc-accent) 55%, var(--sc-surface-border));"
+                  else
+                    "background: var(--sc-surface-border);"
+                  end
+                }
+              >
+              </span>
+            </label>
+          </:between_item>
         </.live_component>
       </div>
       
@@ -142,6 +182,46 @@ defmodule SelectoComponents.Views.Graph.Form do
               theme={@theme}
             />
           </:item_form>
+          <:between_item :let={{id, _item, config, _index, {next_id, _next_item, _next_config}}}>
+            <% linked? = linked_to_next?(config) %>
+            <% toggle_id = "graph-series-link-#{id}-#{next_id}-#{if linked?, do: "on", else: "off"}" %>
+            <label
+              for={toggle_id}
+              class="group flex items-center gap-1.5"
+              title="Link this series field to the next one"
+              aria-label="Link this series field to the next one"
+            >
+              <span class="h-px w-4 transition" style="background: var(--sc-surface-border);"></span>
+              <input type="hidden" name={"series[#{id}][linked_to_next]"} value="false" />
+              <input
+                id={toggle_id}
+                type="checkbox"
+                name={"series[#{id}][linked_to_next]"}
+                value="true"
+                checked={linked?}
+                class="h-3.5 w-3.5 cursor-pointer rounded-full border transition hover:scale-110"
+                style={
+                  if linked? do
+                    "border-color: var(--sc-accent); background: var(--sc-accent-soft); accent-color: var(--sc-accent);"
+                  else
+                    "border-color: var(--sc-surface-border); background: var(--sc-surface-bg-alt); accent-color: var(--sc-accent);"
+                  end
+                }
+              />
+              <span class="sr-only">Link next series field</span>
+              <span
+                class="h-px w-4 transition"
+                style={
+                  if linked? do
+                    "background: color-mix(in srgb, var(--sc-accent) 55%, var(--sc-surface-border));"
+                  else
+                    "background: var(--sc-surface-border);"
+                  end
+                }
+              >
+              </span>
+            </label>
+          </:between_item>
         </.live_component>
       </div>
       
@@ -325,4 +405,13 @@ defmodule SelectoComponents.Views.Graph.Form do
   end
 
   defp present_summary?(value), do: value not in [nil, ""]
+
+  defp linked_to_next?(config) when is_map(config) do
+    case Map.get(config, "linked_to_next", Map.get(config, :linked_to_next)) do
+      value when value in [true, "true", "on", "1", 1] -> true
+      _ -> false
+    end
+  end
+
+  defp linked_to_next?(_config), do: false
 end

--- a/lib/selecto_components/views/graph/process.ex
+++ b/lib/selecto_components/views/graph/process.ex
@@ -221,7 +221,7 @@ defmodule SelectoComponents.Views.Graph.Process do
 
         case_sql =
           BucketParser.generate_bucket_case_sql(
-            "EXTRACT(DAY FROM AGE(CURRENT_DATE, #{field_with_alias}))",
+            "(CURRENT_DATE - DATE(#{field_with_alias}))",
             bucket_ranges,
             :integer
           )

--- a/lib/selecto_components/views/graph/process.ex
+++ b/lib/selecto_components/views/graph/process.ex
@@ -97,6 +97,17 @@ defmodule SelectoComponents.Views.Graph.Process do
       if col == nil do
         nil
       else
+        col =
+          if is_map(col) do
+            linked? = truthy_param?(Map.get(field_config, "linked_to_next"))
+
+            col
+            |> Map.put(:linked_to_next, linked?)
+            |> Map.put("linked_to_next", linked?)
+          else
+            col
+          end
+
         # Generate alias
         alias_name =
           case field_config["alias"] do
@@ -128,6 +139,9 @@ defmodule SelectoComponents.Views.Graph.Process do
     end)
     |> Enum.reject(&is_nil/1)
   end
+
+  defp truthy_param?(value) when value in [true, "true", "on", "1", 1], do: true
+  defp truthy_param?(_), do: false
 
   @doc """
   Process aggregate fields (for Y-axis)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SelectoComponents.MixProject do
   def project do
     [
       app: :selecto_components,
-      version: "0.4.5",
+      version: "0.4.6",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description:

--- a/test/selecto_components/components/list_picker_test.exs
+++ b/test/selecto_components/components/list_picker_test.exs
@@ -5,7 +5,7 @@ defmodule SelectoComponents.Components.ListPickerTest do
 
   alias SelectoComponents.Components.ListPicker
 
-  defp base_assigns(overrides \\ %{}) do
+  defp base_assigns(overrides) do
     base = %{
       id: "test-list-picker",
       view: {"detail", nil, nil, nil},
@@ -52,5 +52,20 @@ defmodule SelectoComponents.Components.ListPickerTest do
     html = render_component(ListPicker, base_assigns(%{selected_items: []}))
 
     assert html =~ "Pick items from the available list to add them here."
+  end
+
+  test "renders a dedicated badge for cte-backed columns" do
+    html =
+      render_component(
+        ListPicker,
+        base_assigns(%{
+          available: [
+            {"active_delivery_projects.priority", "Active Project Priority",
+             %{type: :integer, icon: :cte, icon_family: :cte}}
+          ]
+        })
+      )
+
+    assert html =~ ~s(data-type-icon="CTE")
   end
 end

--- a/test/selecto_components/exporter/dataset_test.exs
+++ b/test/selecto_components/exporter/dataset_test.exs
@@ -18,10 +18,11 @@ defmodule SelectoComponents.Exporter.DatasetTest do
 
     assert dataset.kind == :table
     assert dataset.headers == ["title", "release_year"]
+    assert dataset.row_keys == ["__col_0", "__col_1"]
 
     assert dataset.rows == [
-             %{"title" => "Film A", "release_year" => 1901},
-             %{"title" => "Film B", "release_year" => 1902}
+             %{"__col_0" => "Film A", "__col_1" => 1901},
+             %{"__col_0" => "Film B", "__col_1" => 1902}
            ]
 
     assert dataset.metadata.row_count == 2

--- a/test/selecto_components/exporter_test.exs
+++ b/test/selecto_components/exporter_test.exs
@@ -218,6 +218,45 @@ defmodule SelectoComponents.ExporterTest do
     assert Base.decode64!(export.browser_content) == export.content
   end
 
+  test "preserves distinct values when export headers repeat" do
+    query_results =
+      {
+        [
+          ["Actor Name", "Category Name", "Customer Name", "Employee Name"]
+        ],
+        ["Name", "Name", "Name", "Name"],
+        []
+      }
+
+    assert {:ok, csv_export} =
+             Exporter.build("csv", query_results,
+               view_mode: :detail,
+               exported_at: @exported_at
+             )
+
+    assert csv_export.content ==
+             "Name,Name,Name,Name\nActor Name,Category Name,Customer Name,Employee Name"
+
+    assert {:ok, json_export} =
+             Exporter.build("json", query_results,
+               view_mode: :detail,
+               exported_at: @exported_at
+             )
+
+    decoded = Jason.decode!(json_export.content)
+
+    assert decoded["columns"] == ["Name", "Name", "Name", "Name"]
+
+    assert decoded["rows"] == [
+             %{
+               "Name" => "Actor Name",
+               "Name (2)" => "Category Name",
+               "Name (3)" => "Customer Name",
+               "Name (4)" => "Employee Name"
+             }
+           ]
+  end
+
   test "returns no_results error for invalid query_results" do
     assert {:error, :no_results} = Exporter.build("csv", nil)
   end

--- a/test/selecto_components/form/column_catalog_test.exs
+++ b/test/selecto_components/form/column_catalog_test.exs
@@ -1,0 +1,60 @@
+defmodule SelectoComponents.Form.ColumnCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias Selecto.Expr, as: X
+  alias SelectoComponents.Form.ColumnCatalog
+
+  defp selecto do
+    domain = %{
+      name: "ColumnCatalogTest",
+      source: %{
+        source_table: "records",
+        primary_key: :id,
+        fields: [:id, :status, :priority],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer, name: "ID"},
+          status: %{type: :string, name: "Status"},
+          priority: %{type: :integer, name: "Priority"}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      query_members: %{
+        ctes: %{
+          active_delivery_projects: %{
+            query: fn selecto ->
+              selecto
+              |> Selecto.select(["id", X.as("priority", "priority")])
+            end,
+            columns: ["id", "priority"],
+            join: [owner_key: :id, related_key: :id, fields: :infer]
+          }
+        }
+      }
+    }
+
+    Selecto.configure(domain, nil)
+  end
+
+  test "picker_columns exposes cte-backed fields with a cte icon" do
+    {_id, _name, metadata} =
+      ColumnCatalog.picker_columns(selecto())
+      |> Enum.find(fn {id, _name, _metadata} ->
+        to_string(id) == "active_delivery_projects.priority"
+      end)
+
+    assert metadata.icon == :cte
+    assert metadata.icon_family == :cte
+    assert metadata.cte_name == "active_delivery_projects"
+  end
+
+  test "required_cte_names_for_fields derives ctes from qualified field ids" do
+    assert ColumnCatalog.required_cte_names_for_fields(selecto(), [
+             "status",
+             "active_delivery_projects.priority",
+             "active_delivery_projects.priority"
+           ]) == ["active_delivery_projects"]
+  end
+end

--- a/test/selecto_components/form/drill_down_filters_test.exs
+++ b/test/selecto_components/form/drill_down_filters_test.exs
@@ -338,6 +338,50 @@ defmodule SelectoComponents.Form.DrillDownFiltersTest do
       assert v2 == "2025-01-01"
     end
 
+    test "handles custom date buckets on date fields" do
+      field_conf = %{type: :date}
+      today = Date.utc_today()
+      today_iso = Date.to_iso8601(today)
+      yesterday_iso = Date.add(today, -1) |> Date.to_iso8601()
+
+      assert {"DATE=", today_value, ""} =
+               DrillDownFilters.determine_filter_comp_and_values(
+                 "today",
+                 field_conf,
+                 %{format: "custom_buckets"}
+               )
+
+      assert today_value == today_iso
+
+      assert {"DATE=", yesterday, ""} =
+               DrillDownFilters.determine_filter_comp_and_values(
+                 "yesterday",
+                 field_conf,
+                 %{format: "custom_buckets"}
+               )
+
+      assert yesterday == yesterday_iso
+
+      assert {"DATE_BETWEEN", two_to_seven_start, two_to_seven_end} =
+               DrillDownFilters.determine_filter_comp_and_values(
+                 "2-7",
+                 field_conf,
+                 %{format: "custom_buckets"}
+               )
+
+      assert two_to_seven_start == Date.add(today, -7) |> Date.to_iso8601()
+      assert two_to_seven_end == Date.add(today, -1) |> Date.to_iso8601()
+
+      assert {"<=", eight_plus_cutoff, ""} =
+               DrillDownFilters.determine_filter_comp_and_values(
+                 "8+",
+                 field_conf,
+                 %{format: "custom_buckets"}
+               )
+
+      assert eight_plus_cutoff == Date.add(today, -8) |> Date.to_iso8601()
+    end
+
     test "prevents SQL injection in date values" do
       field_conf = %{type: :date}
 
@@ -561,6 +605,30 @@ defmodule SelectoComponents.Form.DrillDownFiltersTest do
 
       assert Enum.any?(filters, fn f -> f["comp"] == "WEEKDAY_SUN1" and f["value"] == "6" end)
       assert Enum.any?(filters, fn f -> f["comp"] == "DAY_OF_MONTH" and f["value"] == "14" end)
+    end
+
+    test "custom bucket drill-down maps date buckets to date-aware filters" do
+      socket =
+        %{assigns: %{selecto: selecto(), used_params: %{}}}
+        |> put_in(
+          [:assigns, :used_params, "group_by"],
+          %{
+            "g0" => %{"field" => "order_date", "index" => "0", "format" => "custom_buckets"}
+          }
+        )
+
+      params = %{
+        "field0" => "order_date",
+        "value0" => "8+",
+        "gidx0" => "0"
+      }
+
+      view_params = DrillDownFilters.build_agg_drill_down_params(params, socket)
+      [filter] = Map.values(view_params["filters"])
+
+      assert filter["comp"] == "<="
+      assert filter["filter"] == "order_date"
+      assert filter["value"] == Date.add(Date.utc_today(), -8) |> Date.to_iso8601()
     end
 
     test "aggregate drill-down params replace prior matching filters but preserve unrelated ones" do

--- a/test/selecto_components/form/list_operations_test.exs
+++ b/test/selecto_components/form/list_operations_test.exs
@@ -1,9 +1,45 @@
 defmodule SelectoComponents.Form.ListOperationsTest do
   use ExUnit.Case, async: true
 
+  alias Selecto.Expr, as: X
+
   defmodule TestLive do
     use Phoenix.LiveView
     use SelectoComponents.Form.EventHandlers.ListOperations
+  end
+
+  defp selecto do
+    domain = %{
+      name: "ListOperationsTest",
+      source: %{
+        source_table: "records",
+        primary_key: :id,
+        fields: [:id, :status, :priority],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer, name: "ID"},
+          status: %{type: :string, name: "Status"},
+          priority: %{type: :integer, name: "Priority"}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      query_members: %{
+        ctes: %{
+          active_delivery_projects: %{
+            query: fn selecto ->
+              selecto
+              |> Selecto.select(["id", X.as("priority", "priority")])
+            end,
+            columns: ["id", "priority"],
+            join: [owner_key: :id, related_key: :id, fields: :infer]
+          }
+        }
+      }
+    }
+
+    Selecto.configure(domain, nil)
   end
 
   defp base_socket do
@@ -11,7 +47,7 @@ defmodule SelectoComponents.Form.ListOperationsTest do
       assigns: %{
         __changed__: %{},
         columns: [],
-        selecto: %{domain: %{}},
+        selecto: selecto(),
         views: [
           {:detail, SelectoComponents.Views.Detail, "Detail", []},
           {:aggregate, SelectoComponents.Views.Aggregate, "Aggregate", []},
@@ -241,6 +277,25 @@ defmodule SelectoComponents.Form.ListOperationsTest do
 
     assert is_binary(new_uuid)
     assert new_uuid != ""
+  end
+
+  test "detail list picker add auto-includes required ctes for cte-backed fields" do
+    {:noreply, updated} =
+      TestLive.handle_info(
+        {:list_picker_add, detail_form_state_query(), "detail", "selected",
+         "active_delivery_projects.priority"},
+        base_socket()
+      )
+
+    assert [
+             {"detail-col-1", "id", _id_cfg},
+             {"detail-col-2", "status", _status_cfg},
+             {_new_uuid, "active_delivery_projects.priority", %{}}
+           ] = updated.assigns.view_config.views.detail.selected
+
+    assert updated.assigns.view_config.ctes == [
+             {"auto-cte-active_delivery_projects", "active_delivery_projects", %{}}
+           ]
   end
 
   test "detail list picker remove preserves aggregate state" do

--- a/test/selecto_components/form/params_state_test.exs
+++ b/test/selecto_components/form/params_state_test.exs
@@ -125,6 +125,30 @@ defmodule SelectoComponents.Form.ParamsStateTest do
     assert params["aggregate"]["k0"]["uuid"] == "51a3f4f6-fcce-4530-8b24-d7927bd120d6"
   end
 
+  test "view_config_to_params preserves linked group-by metadata" do
+    view_config = %{
+      view_mode: "aggregate",
+      filters: [],
+      views: %{
+        aggregate: %{
+          group_by: [
+            {"12b1e264-6359-4f7d-881a-f3c659fd8606", "shipper.co_name",
+             %{"alias" => "", "format" => "default", "linked_to_next" => true}},
+            {"51a3f4f6-fcce-4530-8b24-d7927bd120d6", "shipper.region",
+             %{"alias" => "", "format" => "default"}}
+          ],
+          aggregate: [],
+          per_page: "100"
+        }
+      }
+    }
+
+    params = ParamsState.view_config_to_params(view_config)
+
+    assert params["group_by"]["k0"]["linked_to_next"] == true
+    refute Map.has_key?(params["group_by"]["k1"], "linked_to_next")
+  end
+
   test "view_config_to_params includes aggregate grid toggle" do
     view_config = %{
       view_mode: "aggregate",

--- a/test/selecto_components/form/params_state_test.exs
+++ b/test/selecto_components/form/params_state_test.exs
@@ -1,6 +1,7 @@
 defmodule SelectoComponents.Form.ParamsStateTest do
   use ExUnit.Case, async: true
 
+  alias Selecto.Expr, as: X
   alias SelectoComponents.Form.ParamsState
 
   defmodule BrokenView do
@@ -20,13 +21,29 @@ defmodule SelectoComponents.Form.ParamsStateTest do
       source: %{
         source_table: "records",
         primary_key: :id,
-        fields: [:id, :status],
+        fields: [:id, :status, :priority],
         redact_fields: [],
-        columns: %{id: %{type: :integer}, status: %{type: :string}},
+        columns: %{
+          id: %{type: :integer, name: "ID"},
+          status: %{type: :string, name: "Status"},
+          priority: %{type: :integer, name: "Priority"}
+        },
         associations: %{}
       },
       schemas: %{},
-      joins: %{}
+      joins: %{},
+      query_members: %{
+        ctes: %{
+          active_delivery_projects: %{
+            query: fn selecto ->
+              selecto
+              |> Selecto.select(["id", X.as("priority", "priority")])
+            end,
+            columns: ["id", "priority"],
+            join: [owner_key: :id, related_key: :id, fields: :infer]
+          }
+        }
+      }
     }
 
     Selecto.configure(domain, nil)
@@ -167,6 +184,43 @@ defmodule SelectoComponents.Form.ParamsStateTest do
 
     assert params["view_mode"] == "aggregate"
     assert params["aggregate_grid"] == "true"
+  end
+
+  test "form_params_to_state derives ctes from cte-backed selected fields" do
+    params = %{
+      "view_mode" => "detail",
+      "selected" => %{
+        "k0" => %{
+          "field" => "active_delivery_projects.priority",
+          "index" => "0",
+          "uuid" => "cte-col-1"
+        }
+      }
+    }
+
+    updated = ParamsState.form_params_to_state(params, base_socket())
+
+    assert updated.assigns.view_config.ctes == [
+             {"auto-cte-active_delivery_projects", "active_delivery_projects", %{}}
+           ]
+  end
+
+  test "view_config_to_params includes derived ctes after cte-backed field selection" do
+    params = %{
+      "view_mode" => "detail",
+      "selected" => %{
+        "k0" => %{
+          "field" => "active_delivery_projects.priority",
+          "index" => "0",
+          "uuid" => "cte-col-1"
+        }
+      }
+    }
+
+    updated = ParamsState.form_params_to_state(params, base_socket())
+    encoded = ParamsState.view_config_to_params(updated.assigns.view_config)
+
+    assert encoded["ctes"]["k0"]["name"] == "active_delivery_projects"
   end
 
   test "view_filter_process preserves duplicate selected_ids values for IN filters" do

--- a/test/selecto_components/helpers/bucket_parser_test.exs
+++ b/test/selecto_components/helpers/bucket_parser_test.exs
@@ -9,6 +9,23 @@ defmodule SelectoComponents.Helpers.BucketParserTest do
                "selecto_root.inserted_at"
     end
 
+    test "maps custom date buckets to current-date-relative date comparisons" do
+      sql =
+        BucketParser.generate_bucket_case_sql(
+          "selecto_root.inserted_at",
+          "today, yesterday, 2-7, 8+",
+          :date
+        )
+
+      assert sql =~ "DATE(selecto_root.inserted_at) = CURRENT_DATE"
+      assert sql =~ "DATE(selecto_root.inserted_at) = CURRENT_DATE - INTERVAL '1 day'"
+
+      assert sql =~
+               "DATE(selecto_root.inserted_at) BETWEEN CURRENT_DATE - INTERVAL '7 day' AND CURRENT_DATE - INTERVAL '2 day'"
+
+      assert sql =~ "DATE(selecto_root.inserted_at) <= CURRENT_DATE - INTERVAL '8 day'"
+    end
+
     test "rejects invalid increment shorthand values" do
       assert BucketParser.generate_bucket_case_sql("selecto_root.price", "*/0", :integer) ==
                "selecto_root.price"

--- a/test/selecto_components/helpers/filters_test.exs
+++ b/test/selecto_components/helpers/filters_test.exs
@@ -3,6 +3,16 @@ defmodule SelectoComponents.Helpers.FiltersTest do
 
   alias SelectoComponents.Helpers.Filters
 
+  defmodule UuidRecord do
+    use Ecto.Schema
+
+    @primary_key {:id, :binary_id, autogenerate: false}
+
+    schema "records" do
+      field(:date_tier_id, Ecto.UUID)
+    end
+  end
+
   defp selecto do
     domain = %{
       name: "FiltersTest",
@@ -81,6 +91,27 @@ defmodule SelectoComponents.Helpers.FiltersTest do
             presentation_type: :utc_datetime,
             datetime_storage: :unix_ms
           }
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{}
+    }
+
+    Selecto.configure(domain, nil)
+  end
+
+  defp uuid_selecto do
+    domain = %{
+      name: "FiltersUuidTest",
+      source: %{
+        source_table: "records",
+        primary_key: :id,
+        fields: [:id, :date_tier_id],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :string},
+          date_tier_id: %{type: :string}
         },
         associations: %{}
       },
@@ -294,6 +325,29 @@ defmodule SelectoComponents.Helpers.FiltersTest do
       sql = IO.iodata_to_binary(iodata)
       assert sql =~ "TO_TIMESTAMP((selecto_root.occurred_at_epoch) / 1000.0)"
       assert sql =~ "EXTRACT(ISODOW FROM"
+    end
+  end
+
+  describe "filter_recurse/3 uuid coercion" do
+    test "dumps UUID multiselect values using schema metadata" do
+      uuid = "759a4832-4b86-44ea-a69d-7aec6f99caaf"
+      {:ok, dumped_uuid} = Ecto.UUID.dump(uuid)
+
+      filters = %{
+        "filters" => [
+          %{
+            "uuid" => "f1",
+            "section" => "filters",
+            "filter" => "date_tier_id",
+            "comp" => "IN",
+            "selected_ids" => [uuid],
+            "value" => uuid
+          }
+        ]
+      }
+
+      [{"date_tier_id", {:in, [^dumped_uuid]}}] =
+        Filters.filter_recurse(uuid_selecto(), filters, "filters")
     end
   end
 end

--- a/test/selecto_components/views/aggregate/component_test.exs
+++ b/test/selecto_components/views/aggregate/component_test.exs
@@ -188,6 +188,102 @@ defmodule SelectoComponents.Views.Aggregate.ComponentTest do
     assert html =~ "Total"
   end
 
+  test "linked group-by blocks collapse into one header and preserve multi-filter drill-down" do
+    domain = %{
+      name: "AggregateLinkedGroupComponentTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :state, :title, :rank, :inserted_at],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer},
+          state: %{type: :string},
+          title: %{type: :string},
+          rank: %{type: :integer},
+          inserted_at: %{type: :date}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{}
+    }
+
+    linked_selecto = Selecto.configure(domain, nil)
+
+    assigns = %{
+      id: "aggregate-linked-group-render-test",
+      executed: true,
+      execution_error: nil,
+      view_config: %{
+        view_mode: "aggregate",
+        filters: [],
+        group_by: %{
+          "g0" => %{"field" => "state", "index" => "0", "linked_to_next" => true},
+          "g1" => %{"field" => "title", "index" => "1", "linked_to_next" => true},
+          "g2" => %{
+            "field" => "rank",
+            "index" => "2",
+            "format" => "buckets",
+            "bucket_ranges" => "0-4",
+            "linked_to_next" => false
+          },
+          "g3" => %{"field" => "inserted_at", "index" => "3"}
+        }
+      },
+      selecto: %{
+        linked_selecto
+        | set: %{
+            selected: [
+              {:field, "state", "State"},
+              {:field, "title", "Title"},
+              {:field, "rank", "Rank"},
+              {:field, "inserted_at", "Inserted At"},
+              {:field, {:count, :id}, "ID Count"}
+            ],
+            groups: [
+              {:field, "state", "State"},
+              {:field, "title", "Title"},
+              {:field, "rank", "Rank"},
+              {:field, "inserted_at", "Inserted At"}
+            ],
+            group_by: [
+              {:rollup,
+               [
+                 {:grouping_set,
+                  [
+                    {:literal_position, 1},
+                    {:literal_position, 2},
+                    {:literal_position, 3}
+                  ]},
+                 {:literal_position, 4}
+               ]}
+            ],
+            aggregates: [{:field, {:count, :id}, "ID Count"}]
+          }
+      },
+      query_results:
+        {[
+           ["done", "ES", "0-4", nil, 32],
+           [nil, nil, nil, nil, 32]
+         ], [], ["state", "title", "rank", "inserted_at", "id_count"]},
+      view_meta: %{exe_id: "aggregate-linked-group-render-test-run"}
+    }
+
+    html = render_component(Component, assigns)
+
+    assert html =~ "State / Title / Rank"
+    assert html =~ "Inserted At"
+    assert html =~ "done / ES / 0-4"
+    assert html =~ ~s(phx-value-field0="state")
+    assert html =~ ~s(phx-value-value0="done")
+    assert html =~ ~s(phx-value-field1="title")
+    assert html =~ ~s(phx-value-value1="ES")
+    assert html =~ ~s(phx-value-field2="rank")
+    assert html =~ ~s(phx-value-value2="0-4")
+    refute html =~ ~s(phx-value-field3="inserted_at")
+  end
+
   test "renders aggregate grid when enabled with 2 group-by and 1 aggregate" do
     assigns = %{
       id: "aggregate-grid-test",

--- a/test/selecto_components/views/aggregate/component_test.exs
+++ b/test/selecto_components/views/aggregate/component_test.exs
@@ -415,7 +415,113 @@ defmodule SelectoComponents.Views.Aggregate.ComponentTest do
         aggregate_assigns(%{view_meta: %{exe_id: "aggregate-grid-message", grid_enabled: true}})
       )
 
-    assert html =~ "Grid view requires exactly 2 Group By fields and 1 Aggregate"
+    assert html =~ "Grid view requires exactly 2 Group By axes and 1 Aggregate"
+  end
+
+  test "grid can use a linked group-by block as one axis" do
+    domain = %{
+      name: "AggregateLinkedGridComponentTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :state, :title, :rank],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer},
+          state: %{type: :string},
+          title: %{type: :string},
+          rank: %{type: :integer}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{}
+    }
+
+    linked_selecto = Selecto.configure(domain, nil)
+
+    assigns = %{
+      id: "aggregate-grid-linked-axis-test",
+      executed: true,
+      execution_error: nil,
+      view_config: %{
+        view_mode: "aggregate",
+        filters: [],
+        group_by: %{
+          "g0" => %{"field" => "state", "index" => "0", "linked_to_next" => true},
+          "g1" => %{
+            "field" => "title",
+            "index" => "1",
+            "format" => "text_prefix",
+            "prefix_length" => "2"
+          },
+          "g2" => %{
+            "field" => "rank",
+            "index" => "2",
+            "format" => "buckets",
+            "bucket_ranges" => "0-4"
+          }
+        }
+      },
+      selecto: %{
+        linked_selecto
+        | set: %{
+            selected: [
+              {:field, "state", "State"},
+              {:field, "title", "Title"},
+              {:field, "rank", "Rank"},
+              {:field, {:count, :id}, "ID Count"}
+            ],
+            groups: [
+              {:field, "state", "State"},
+              {:field, "title", "Title"},
+              {:field, "rank", "Rank"}
+            ],
+            group_by: [
+              {:rollup,
+               [
+                 {:grouping_set, [{:literal_position, 1}, {:literal_position, 2}]},
+                 {:literal_position, 3}
+               ]}
+            ],
+            aggregates: [{:field, {:count, :id}, "ID Count"}],
+            gb_params: %{
+              "g0" => %{"field" => "state", "index" => "0", "linked_to_next" => true},
+              "g1" => %{
+                "field" => "title",
+                "index" => "1",
+                "format" => "text_prefix",
+                "prefix_length" => "2"
+              },
+              "g2" => %{
+                "field" => "rank",
+                "index" => "2",
+                "format" => "buckets",
+                "bucket_ranges" => "0-4"
+              }
+            }
+          }
+      },
+      query_results:
+        {[
+           ["done", "ES", "0-4", 32],
+           ["planned", "BU", "0-4", 8]
+         ], [], ["state", "title", "rank", "id_count"]},
+      view_meta: %{exe_id: "aggregate-grid-linked-axis-run", grid_enabled: true}
+    }
+
+    html = render_component(Component, assigns)
+
+    assert html =~ "Aggregate Grid"
+    assert html =~ "State / Title"
+    assert html =~ "done / ES"
+    assert html =~ "planned / BU"
+    assert html =~ ~s(phx-value-field0="state")
+    assert html =~ ~s(phx-value-value0="done")
+    assert html =~ ~s(phx-value-field1="title")
+    assert html =~ ~s(phx-value-value1="ES")
+    assert html =~ ~s(phx-value-field2="rank")
+    assert html =~ ~s(phx-value-value2="0-4")
   end
 
   test "grid view sorts hour-of-day columns numerically" do

--- a/test/selecto_components/views/aggregate/form_test.exs
+++ b/test/selecto_components/views/aggregate/form_test.exs
@@ -178,6 +178,53 @@ defmodule SelectoComponents.Views.Aggregate.FormTest do
     refute html =~ "Count Distinct"
   end
 
+  test "group by form shows link controls between adjacent selected items" do
+    domain = %{
+      name: "AggregateFormTest",
+      source: %{
+        source_table: "items",
+        primary_key: :id,
+        fields: [:city, :state],
+        redact_fields: [],
+        columns: %{
+          city: %{type: :string, name: "City", colid: :city},
+          state: %{type: :string, name: "State", colid: :state}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{}
+    }
+
+    html =
+      render_component(Form, %{
+        id: "aggregate-form-group-link-test",
+        columns: [{:city, "City", :string}, {:state, "State", :string}],
+        view: {:aggregate, SelectoComponents.Views.Aggregate, "Aggregate", %{}},
+        selecto: Selecto.configure(domain, nil),
+        view_config: %{
+          views: %{
+            aggregate: %{
+              group_by: [
+                {"group-1", "city", %{"format" => "default", "linked_to_next" => true}},
+                {"group-2", "state", %{"format" => "default"}}
+              ],
+              aggregate: [],
+              per_page: "30"
+            }
+          }
+        }
+      })
+
+    assert html =~
+             ~r/<input[^>]+type="hidden"[^>]+name="group_by\[group-1\]\[linked_to_next\]"[^>]+value="false"/
+
+    assert html =~
+             ~r/<input[^>]+id="group-by-link-group-1-group-2-on"[^>]+name="group_by\[group-1\]\[linked_to_next\]"[^>]+checked/
+
+    refute html =~ ~s(id="group-by-link-group-2-group-)
+  end
+
   test "aggregate config uses themed labels and checkbox surfaces" do
     html =
       render_component(Config, %{

--- a/test/selecto_components/views/aggregate/process_test.exs
+++ b/test/selecto_components/views/aggregate/process_test.exs
@@ -137,20 +137,25 @@ defmodule SelectoComponents.Views.Aggregate.ProcessTest do
       }
     }
 
-    assert Process.group_by(
-             %{"g1" => %{"field" => "category.category_name", "format" => "default"}},
-             columns,
-             nil
-           ) ==
-             [
-               {%{
-                  "group_format" => "default",
-                  name: "Category: Category name",
-                  type: :string,
-                  colid: "category.category_name",
-                  group_format: "default"
-                }, {:field, "category.category_name", "Category Name"}}
-             ]
+    [{coldef, selector}] =
+      Process.group_by(
+        %{"g1" => %{"field" => "category.category_name", "format" => "default"}},
+        columns,
+        nil
+      )
+
+    assert selector == {:field, "category.category_name", "Category Name"}
+
+    assert Map.take(coldef, [:name, :type, :colid, :group_format, :linked_to_next]) == %{
+             name: "Category: Category name",
+             type: :string,
+             colid: "category.category_name",
+             group_format: "default",
+             linked_to_next: false
+           }
+
+    assert coldef["group_format"] == "default"
+    assert coldef["linked_to_next"] == false
   end
 
   test "aggregates use friendly default labels" do
@@ -232,5 +237,42 @@ defmodule SelectoComponents.Views.Aggregate.ProcessTest do
       )
 
     assert {:field, "date_tier.id", "Date Tier"} = hd(view_set.selected)
+  end
+
+  test "view collapses linked group by items into rollup grouping sets" do
+    columns = %{
+      "city" => %{name: "City", type: :string, colid: "city"},
+      "state" => %{name: "State", type: :string, colid: "state"},
+      "country" => %{name: "Country", type: :string, colid: "country"}
+    }
+
+    {view_set, _meta} =
+      Process.view(
+        nil,
+        %{
+          "group_by" => %{
+            "g0" => %{"field" => "city", "index" => "0", "linked_to_next" => "true"},
+            "g1" => %{"field" => "state", "index" => "1"},
+            "g2" => %{"field" => "country", "index" => "2"}
+          }
+        },
+        columns,
+        [],
+        nil
+      )
+
+    assert view_set.group_by == [
+             {:rollup,
+              [
+                {:grouping_set,
+                 [
+                   {:field, {:coalesce, ["city", {:literal, "[NULL]"}]}, "City"},
+                   {:field, {:coalesce, ["state", {:literal, "[NULL]"}]}, "State"}
+                 ]},
+                {:field, {:coalesce, ["country", {:literal, "[NULL]"}]}, "Country"}
+              ]}
+           ]
+
+    assert length(view_set.groups) == 3
   end
 end

--- a/test/selecto_components/views/aggregate/process_test.exs
+++ b/test/selecto_components/views/aggregate/process_test.exs
@@ -3,6 +3,67 @@ defmodule SelectoComponents.Views.Aggregate.ProcessTest do
 
   alias SelectoComponents.Views.Aggregate.Process
 
+  defmodule Registration do
+    use Ecto.Schema
+
+    @primary_key {:id, :binary_id, autogenerate: false}
+
+    schema "registrations" do
+      field(:date_tier_id, Ecto.UUID)
+    end
+  end
+
+  defmodule DateTier do
+    use Ecto.Schema
+
+    @primary_key {:id, :binary_id, autogenerate: false}
+
+    schema "date_tiers" do
+      field(:name, :string)
+    end
+  end
+
+  defp uuid_join_selecto do
+    domain = %{
+      name: "AggregateUuidTest",
+      source: %{
+        source_table: "registrations",
+        primary_key: :id,
+        fields: [:id, :date_tier_id],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :string},
+          date_tier_id: %{type: :string}
+        },
+        associations: %{}
+      },
+      schemas: %{
+        date_tier: %{
+          source_table: "date_tiers",
+          primary_key: :id,
+          fields: [:id, :name],
+          columns: %{
+            id: %{
+              name: "Date Tier",
+              type: :string,
+              join_mode: :lookup,
+              filter_type: :multi_select_id,
+              display_field: :name,
+              group_by_filter: "date_tier_id"
+            },
+            name: %{
+              name: "Date Tier Name",
+              type: :string
+            }
+          }
+        }
+      },
+      joins: %{}
+    }
+
+    Selecto.configure(domain, nil)
+  end
+
   test "param_to_state reads aggregate grid toggle" do
     state = Process.param_to_state(%{"aggregate_grid" => "true"}, %{})
     assert state.grid == true
@@ -152,5 +213,24 @@ defmodule SelectoComponents.Views.Aggregate.ProcessTest do
     assert {:field, {:raw_sql, sql}, "Delivery Team Inserted At"} = selector
     assert sql =~ "EXTRACT(YEAR FROM delivery_team.inserted_at)"
     refute sql =~ "EXTRACT(YEAR FROM t.inserted_at)"
+  end
+
+  test "view does not wrap UUID group-bys in text coalesce" do
+    selecto = uuid_join_selecto()
+
+    columns = %{
+      "date_tier.id" => %{name: "Date Tier", type: :string, colid: "date_tier.id"}
+    }
+
+    {view_set, _meta} =
+      Process.view(
+        nil,
+        %{"group_by" => %{"g1" => %{"field" => "date_tier.id", "index" => "0"}}},
+        columns,
+        [],
+        selecto
+      )
+
+    assert {:field, "date_tier.id", "Date Tier"} = hd(view_set.selected)
   end
 end

--- a/test/selecto_components/views/graph/component_test.exs
+++ b/test/selecto_components/views/graph/component_test.exs
@@ -136,6 +136,95 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
       assert chart_data.labels == []
       assert chart_data.datasets == []
     end
+
+    test "collapses linked x-axis fields into grouped labels and drill-down specs" do
+      assigns = %{
+        selecto: %{
+          set: %{
+            x_axis_groups: [
+              {%{colid: :state, linked_to_next: true}, {:field, :state, "State"}},
+              {%{colid: :title_prefix, linked_to_next: false}, {:field, :title_prefix, "Title"}}
+            ],
+            aggregates: [
+              {:field, {:count, "id"}, "Count"}
+            ],
+            series_groups: [],
+            chart_type: "bar"
+          }
+        }
+      }
+
+      results = [
+        ["done", "ES", 32],
+        ["todo", "BU", 14]
+      ]
+
+      chart_data = Component.prepare_chart_data(assigns, results, ["State", "Title", "Count"])
+
+      assert chart_data.labels == ["done / ES", "todo / BU"]
+
+      [dataset] = chart_data.datasets
+      assert dataset.data == [32, 14]
+
+      assert dataset.drillDown == [
+               [
+                 %{field: "state", value: "done", gidx: "0"},
+                 %{field: "title_prefix", value: "ES", gidx: "1"}
+               ],
+               [
+                 %{field: "state", value: "todo", gidx: "0"},
+                 %{field: "title_prefix", value: "BU", gidx: "1"}
+               ]
+             ]
+    end
+
+    test "builds grouped series datasets with full drill-down specs" do
+      assigns = %{
+        selecto: %{
+          set: %{
+            x_axis_groups: [
+              {%{colid: :state, linked_to_next: false}, {:field, :state, "State"}}
+            ],
+            aggregates: [
+              {:field, {:count, "id"}, "Count"}
+            ],
+            series_groups: [
+              {%{colid: :rank_bucket, linked_to_next: true}, {:field, :rank_bucket, "Rank"}},
+              {%{colid: :assignee_role, linked_to_next: false},
+               {:field, :assignee_role, "Role"}}
+            ],
+            chart_type: "line"
+          }
+        }
+      }
+
+      results = [
+        ["done", "0-4", "software_engineer", 32],
+        ["todo", "0-4", "software_engineer", 10]
+      ]
+
+      chart_data = Component.prepare_chart_data(assigns, results, ["State", "Rank", "Role", "Count"])
+
+      assert chart_data.labels == ["done", "todo"]
+      assert length(chart_data.datasets) == 1
+
+      [dataset] = chart_data.datasets
+      assert dataset.label == "Count - 0-4 / software_engineer"
+      assert dataset.data == [32, 10]
+
+      assert dataset.drillDown == [
+               [
+                 %{field: "state", value: "done", gidx: "0"},
+                 %{field: "rank_bucket", value: "0-4", gidx: "1"},
+                 %{field: "assignee_role", value: "software_engineer", gidx: "2"}
+               ],
+               [
+                 %{field: "state", value: "todo", gidx: "0"},
+                 %{field: "rank_bucket", value: "0-4", gidx: "1"},
+                 %{field: "assignee_role", value: "software_engineer", gidx: "2"}
+               ]
+             ]
+    end
   end
 
   describe "prepare_chart_options/1" do

--- a/test/selecto_components/views/graph/component_test.exs
+++ b/test/selecto_components/views/graph/component_test.exs
@@ -190,8 +190,7 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
             ],
             series_groups: [
               {%{colid: :rank_bucket, linked_to_next: true}, {:field, :rank_bucket, "Rank"}},
-              {%{colid: :assignee_role, linked_to_next: false},
-               {:field, :assignee_role, "Role"}}
+              {%{colid: :assignee_role, linked_to_next: false}, {:field, :assignee_role, "Role"}}
             ],
             chart_type: "line"
           }
@@ -203,7 +202,8 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
         ["todo", "0-4", "software_engineer", 10]
       ]
 
-      chart_data = Component.prepare_chart_data(assigns, results, ["State", "Rank", "Role", "Count"])
+      chart_data =
+        Component.prepare_chart_data(assigns, results, ["State", "Rank", "Role", "Count"])
 
       assert chart_data.labels == ["done", "todo"]
       assert length(chart_data.datasets) == 1

--- a/test/selecto_components/views/graph/drill_down_test.exs
+++ b/test/selecto_components/views/graph/drill_down_test.exs
@@ -55,12 +55,12 @@ defmodule SelectoComponents.Views.Graph.DrillDownTest do
           views: %{
             graph: %{
               x_axis: [
-                {"x1", "state", %{"field" => "state", "index" => "0", "linked_to_next" => "true"}},
+                {"x1", "state",
+                 %{"field" => "state", "index" => "0", "linked_to_next" => "true"}},
                 {"x2", "title", %{"field" => "title", "index" => "1", "format" => "text_prefix"}}
               ],
               series: [
-                {"s1", "rank",
-                 %{"field" => "rank", "index" => "0", "bucket_ranges" => "*/5"}}
+                {"s1", "rank", %{"field" => "rank", "index" => "0", "bucket_ranges" => "*/5"}}
               ]
             }
           },
@@ -77,7 +77,11 @@ defmodule SelectoComponents.Views.Graph.DrillDownTest do
           config: %{columns: %{}, domain_data: %{}},
           set: %{}
         },
-        columns: [{"state", "State", :string}, {"title", "Title", :string}, {"rank", "Rank", :integer}],
+        columns: [
+          {"state", "State", :string},
+          {"title", "Title", :string},
+          {"rank", "Rank", :integer}
+        ],
         views: [{:graph, nil, "Graph", %{drill_down: :detail}}],
         used_params: %{
           "x_axis" => %{
@@ -113,7 +117,8 @@ defmodule SelectoComponents.Views.Graph.DrillDownTest do
            end)
 
     assert Enum.any?(filters, fn {_id, _section, filter} ->
-             filter["filter"] == "title" and filter["comp"] == "STARTS" and filter["value"] == "es"
+             filter["filter"] == "title" and filter["comp"] == "STARTS" and
+               filter["value"] == "es"
            end)
 
     assert Enum.any?(filters, fn {_id, _section, filter} ->

--- a/test/selecto_components/views/graph/drill_down_test.exs
+++ b/test/selecto_components/views/graph/drill_down_test.exs
@@ -45,4 +45,80 @@ defmodule SelectoComponents.Views.Graph.DrillDownTest do
     {_id, _section, filter_map} = List.last(updated_socket.assigns.view_config.filters)
     assert filter_map["filter"] == "recorded_at"
   end
+
+  test "applies indexed grouped graph drill-down as multiple filters" do
+    socket = %Phoenix.LiveView.Socket{
+      assigns: %{
+        __changed__: %{},
+        view_config: %{
+          view_mode: "graph",
+          views: %{
+            graph: %{
+              x_axis: [
+                {"x1", "state", %{"field" => "state", "index" => "0", "linked_to_next" => "true"}},
+                {"x2", "title", %{"field" => "title", "index" => "1", "format" => "text_prefix"}}
+              ],
+              series: [
+                {"s1", "rank",
+                 %{"field" => "rank", "index" => "0", "bucket_ranges" => "*/5"}}
+              ]
+            }
+          },
+          filters: []
+        },
+        selecto: %{
+          domain: %{
+            custom_columns: %{
+              "state" => %{colid: "state", field: "state", type: :string},
+              "title" => %{colid: "title", field: "title", type: :string},
+              "rank" => %{colid: "rank", field: "rank", type: :integer}
+            }
+          },
+          config: %{columns: %{}, domain_data: %{}},
+          set: %{}
+        },
+        columns: [{"state", "State", :string}, {"title", "Title", :string}, {"rank", "Rank", :integer}],
+        views: [{:graph, nil, "Graph", %{drill_down: :detail}}],
+        used_params: %{
+          "x_axis" => %{
+            "x1" => %{"field" => "state", "index" => "0", "linked_to_next" => "true"},
+            "x2" => %{"field" => "title", "index" => "1", "format" => "text_prefix"}
+          },
+          "series" => %{
+            "s1" => %{"field" => "rank", "index" => "0", "bucket_ranges" => "*/5"}
+          }
+        }
+      }
+    }
+
+    params = %{
+      "field0" => "state",
+      "value0" => "done",
+      "gidx0" => "0",
+      "field1" => "title",
+      "value1" => "ES",
+      "gidx1" => "1",
+      "field2" => "rank",
+      "value2" => "0-4",
+      "gidx2" => "2"
+    }
+
+    assert {:ok, updated_socket, _view_params} = DrillDown.apply(socket, params)
+
+    filters = updated_socket.assigns.view_config.filters
+    assert length(filters) == 3
+
+    assert Enum.any?(filters, fn {_id, _section, filter} ->
+             filter["filter"] == "state" and filter["comp"] == "=" and filter["value"] == "done"
+           end)
+
+    assert Enum.any?(filters, fn {_id, _section, filter} ->
+             filter["filter"] == "title" and filter["comp"] == "STARTS" and filter["value"] == "es"
+           end)
+
+    assert Enum.any?(filters, fn {_id, _section, filter} ->
+             filter["filter"] == "rank" and filter["comp"] == "BETWEEN" and
+               filter["value_start"] == "0" and filter["value_end"] == "4"
+           end)
+  end
 end

--- a/test/selecto_components/views/graph/form_test.exs
+++ b/test/selecto_components/views/graph/form_test.exs
@@ -118,11 +118,15 @@ defmodule SelectoComponents.Views.Graph.FormTest do
 
       x_axis_picker = list_picker(rendered, "x_axis")
       y_axis_picker = list_picker(rendered, "y_axis")
+      series_picker = list_picker(rendered, "series")
 
       assert x_axis_picker.assigns.fieldname == "x_axis"
       assert y_axis_picker.assigns.fieldname == "y_axis"
+      assert series_picker.assigns.fieldname == "series"
       assert x_axis_picker.assigns.selected_items != []
       assert y_axis_picker.assigns.selected_items != []
+      assert x_axis_picker.assigns.between_item != []
+      assert series_picker.assigns.between_item != []
     end
 
     test "renders with minimal configuration" do

--- a/test/selecto_components/views/graph/integration_test.exs
+++ b/test/selecto_components/views/graph/integration_test.exs
@@ -116,8 +116,11 @@ defmodule SelectoComponents.Views.Graph.IntegrationTest do
       chart_data = Component.prepare_chart_data(assigns, query_results, aliases)
 
       # Should group data properly for multi-series bar chart
-      assert length(chart_data.labels) > 0
-      assert length(chart_data.datasets) > 0
+      assert chart_data.labels == ["Action", "Comedy", "Drama"]
+      assert length(chart_data.datasets) == 3
+      assert Enum.any?(chart_data.datasets, &(&1.label == "Number of Films - PG-13"))
+      assert Enum.any?(chart_data.datasets, &(&1.label == "Number of Films - R"))
+      assert Enum.any?(chart_data.datasets, &(&1.label == "Number of Films - PG"))
 
       # Step 7: Test component rendering
       render_assigns = %{

--- a/test/selecto_components/views/graph/process_test.exs
+++ b/test/selecto_components/views/graph/process_test.exs
@@ -7,7 +7,12 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
     test "converts form parameters to view state" do
       params = %{
         "x_axis" => %{
-          "1" => %{"field" => "category", "index" => "0", "alias" => "Category"},
+          "1" => %{
+            "field" => "category",
+            "index" => "0",
+            "alias" => "Category",
+            "linked_to_next" => "true"
+          },
           "2" => %{"field" => "release_year", "index" => "1", "alias" => ""}
         },
         "y_axis" => %{
@@ -37,6 +42,7 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
       [first_x, second_x] = state.x_axis
       assert elem(first_x, 1) == "category"
       assert elem(second_x, 1) == "release_year"
+      assert get_in(elem(first_x, 2), ["linked_to_next"]) == "true"
     end
 
     test "handles empty parameters gracefully" do
@@ -172,6 +178,40 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
       group_fields = Enum.map(view_set.groups, fn {col, _} -> col.colid end)
       assert :category in group_fields
       assert :rating in group_fields
+    end
+
+    test "preserves linked graph group metadata on x-axis and series fields", %{columns: columns} do
+      params = %{
+        "x_axis" => %{
+          "1" => %{
+            "field" => "category",
+            "index" => "0",
+            "alias" => "Category",
+            "linked_to_next" => "true"
+          },
+          "2" => %{"field" => "release_year", "index" => "1", "alias" => "Year"}
+        },
+        "y_axis" => %{
+          "1" => %{
+            "field" => "film_count",
+            "index" => "0",
+            "function" => "count",
+            "alias" => "Count"
+          }
+        },
+        "series" => %{
+          "1" => %{"field" => "rating", "index" => "0", "alias" => "Rating"}
+        }
+      }
+
+      {view_set, _} = Process.view(nil, params, columns, [], nil)
+
+      [{first_x_col, _}, {second_x_col, _}] = view_set.x_axis_groups
+      [{series_col, _}] = view_set.series_groups
+
+      assert first_x_col.linked_to_next == true
+      assert second_x_col.linked_to_next == false
+      assert series_col.linked_to_next == false
     end
 
     test "handles datetime fields with format options", %{columns: columns} do


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the codebase, focusing on enhanced support for CTE-backed fields, improved export stability (especially with duplicate headers and UUIDs), and better handling of multi-select filters. The changes also include UI enhancements for aggregate/group-by controls and various bug fixes for filter and export workflows.

**Enhancements for CTE-backed fields and aggregate/group-by controls:**

* CTE-backed fields are now available directly in the normal view-column pickers, marked with a dedicated `CTE` badge. Required CTEs are automatically derived, persisted, and reapplied when selecting, reordering, submitting, or restoring views, ensuring smooth round-tripping and loading of CTE-backed project views. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R34) [[2]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR833) [[3]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR869-R871)
* Aggregate/group-by controls now allow adjacent linking, letting users chain neighboring dimensions into composite rollup/grouping blocks. The backend and UI have been updated so linked group blocks execute as a single grouped element, and the table rendering displays them as a combined header/value pair, with drill-downs applying the full linked filter set. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R34) [[2]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR22) [[3]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR167-R170) [[4]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR231-R239)

**Export and dataset stability improvements:**

* The export system now handles duplicate column headers by generating unique headers in the output, ensuring stable dataset/export results even when selected fields or aliases collide. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R34) [[2]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6L45-R45) [[3]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6L98-R98) [[4]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6L163-R162) [[5]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6L201-R223)
* The dataset normalization logic has been refactored to use stable row keys, supporting both table and grid kinds, and ensuring value alignment even with duplicate or aliased headers. [[1]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44R7) [[2]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44R73-R84) [[3]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44R110) [[4]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L284-R329)

**Filter and UUID handling fixes:**

* Multi-select filters now correctly preserve and coerce UUID values across apply/restore paths, and filter widgets and processors handle UUIDs robustly. The filter event handling and option normalization logic have been updated accordingly. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R34) [[2]](diffhunk://#diff-f9fa4d49cfdb71239db25815ae51b215edf5b771a22cce8993c1ba3628ce2c87L142-L161) [[3]](diffhunk://#diff-f9fa4d49cfdb71239db25815ae51b215edf5b771a22cce8993c1ba3628ce2c87L250-R243) [[4]](diffhunk://#diff-f9fa4d49cfdb71239db25815ae51b215edf5b771a22cce8993c1ba3628ce2c87L312-R317)
* Aggregate drill-down filter promotion and related interactions now correctly preserve expected filter state, avoiding filter loss or misapplication.

**Other bug fixes and improvements:**

* Fixed custom datetime bucket SQL generation to ensure relative date buckets (like "today", "yesterday", "2-7", "8+") compile into valid SQL expressions.
* The denormalization detector now skips CTE joins, preventing incorrect denormalization warnings for CTE-backed fields. [[1]](diffhunk://#diff-da93b09ab4dc80d4f7741c3c57f06a756b8519d6501d53ce97d06539d81d4eb9R256-R258) [[2]](diffhunk://#diff-da93b09ab4dc80d4f7741c3c57f06a756b8519d6501d53ce97d06539d81d4eb9R270)
* Removed unused or unsupported controller multi-select filter code for clarity and maintainability. [[1]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330L684-L686) [[2]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330L708-L718)

**UI and code structure improvements:**

* Added visual and style support for CTE badges, including a new icon and color scheme in the list picker. [[1]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR790-R793) [[2]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR833) [[3]](diffhunk://#diff-c219e75183b37f860b4054c8eddb45eb4ea641092e7298ddc0c1861bfabc472fR869-R871)
* Refactored form rendering to use a `form_selecto` with the new column catalog logic, improving modularity and maintainability. [[1]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R8) [[2]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R32-R40) [[3]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330L196-R200) [[4]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330L174-R178)

These updates collectively improve discoverability, stability, and user experience for advanced field selection, filtering, and data export workflows.