### PR TITLE
Feat/presentation runtime

### DIFF
--- a/lib/selecto_components/exporter.ex
+++ b/lib/selecto_components/exporter.ex
@@ -36,10 +36,14 @@ defmodule SelectoComponents.Exporter do
     exported_at = exported_at(opts)
     view_mode = normalize_view_mode(Keyword.get(opts, :view_mode, "results"))
     filename = "selecto_#{view_mode}_#{filename_timestamp(exported_at)}.json"
+    export_mode = normalize_export_mode(Keyword.get(opts, :export_mode, :raw))
+    presentation_context = Keyword.get(opts, :presentation_context, %{})
 
     payload = %{
       exported_at: DateTime.to_iso8601(exported_at),
       view_mode: view_mode,
+      export_mode: export_mode,
+      presentation_context: presentation_context,
       row_count: length(dataset.rows),
       columns: dataset.headers,
       rows: json_rows(dataset)
@@ -352,6 +356,10 @@ defmodule SelectoComponents.Exporter do
   defp normalize_view_mode(view_mode) when is_atom(view_mode), do: Atom.to_string(view_mode)
   defp normalize_view_mode(view_mode) when is_binary(view_mode), do: view_mode
   defp normalize_view_mode(_view_mode), do: "results"
+
+  defp normalize_export_mode(mode) when mode in [:raw, :display], do: Atom.to_string(mode)
+  defp normalize_export_mode("display"), do: "display"
+  defp normalize_export_mode(_mode), do: "raw"
 
   defp exported_at(opts) do
     case Keyword.get(opts, :exported_at) do

--- a/lib/selecto_components/exporter/dataset.ex
+++ b/lib/selecto_components/exporter/dataset.ex
@@ -1,6 +1,8 @@
 defmodule SelectoComponents.Exporter.Dataset do
   @moduledoc false
 
+  alias SelectoComponents.Presentation
+
   @type t :: %{
           kind: :table | :grid,
           headers: [String.t()],
@@ -15,7 +17,7 @@ defmodule SelectoComponents.Exporter.Dataset do
     if aggregate_grid_export?(opts) do
       build_grid_dataset(query_results, opts)
     else
-      build_table_dataset(query_results)
+      build_table_dataset(query_results, opts)
     end
   end
 
@@ -68,13 +70,20 @@ defmodule SelectoComponents.Exporter.Dataset do
 
   def value_to_string(value), do: to_string(sanitize_value(value))
 
-  defp build_table_dataset({rows, columns, _aliases}) do
+  defp build_table_dataset({rows, columns, _aliases} = query_results, opts) do
     headers = headers(columns, rows)
     row_keys = Enum.map(0..max(length(headers) - 1, 0), &"__col_#{&1}")
+    row_column_defs = row_column_defs(opts, query_results)
+    presentation_context = Keyword.get(opts, :presentation_context, %{})
+    export_mode = Keyword.get(opts, :export_mode, :raw)
 
     normalized_rows =
       Enum.map(rows, fn row ->
-        normalize_row(row, columns, headers, row_keys)
+        normalize_row(row, columns, headers, row_keys,
+          row_column_defs: row_column_defs,
+          presentation_context: presentation_context,
+          export_mode: export_mode
+        )
       end)
 
     {:ok,
@@ -83,7 +92,11 @@ defmodule SelectoComponents.Exporter.Dataset do
        headers: headers,
        row_keys: row_keys,
        rows: normalized_rows,
-       metadata: %{row_count: length(normalized_rows)}
+       metadata: %{
+         row_count: length(normalized_rows),
+         export_mode: export_mode,
+         presentation_context: presentation_context
+       }
      }}
   end
 
@@ -285,43 +298,110 @@ defmodule SelectoComponents.Exporter.Dataset do
     end
   end
 
-  defp normalize_row(row, columns, headers, row_keys) when is_map(row) do
+  defp row_column_defs(opts, {_rows, columns, aliases}) do
+    selecto = Keyword.get(opts, :selecto)
+
+    Enum.with_index(columns)
+    |> Enum.reduce(%{}, fn {column_name, idx}, acc ->
+      alias_name = Enum.at(aliases, idx)
+      column_def = find_column_def(selecto, column_name, alias_name)
+
+      acc
+      |> Map.put(idx, column_def)
+      |> maybe_put_alias_column_def(alias_name, column_def)
+      |> Map.put_new(to_string(column_name), column_def)
+    end)
+  end
+
+  defp row_column_defs(_opts, _query_results), do: %{}
+
+  defp maybe_put_alias_column_def(acc, nil, _column_def), do: acc
+
+  defp maybe_put_alias_column_def(acc, alias_name, column_def),
+    do: Map.put_new(acc, to_string(alias_name), column_def)
+
+  defp find_column_def(nil, _column_name, _alias_name), do: nil
+
+  defp find_column_def(selecto, column_name, alias_name) do
+    configured_column(selecto, column_name) ||
+      configured_column(selecto, alias_name) ||
+      Selecto.field(selecto, column_name) ||
+      if(alias_name, do: Selecto.field(selecto, alias_name), else: nil)
+  end
+
+  defp configured_column(_selecto, nil), do: nil
+
+  defp configured_column(selecto, key) do
+    columns = Selecto.columns(selecto)
+
+    Map.get(columns, key) ||
+      case key do
+        value when is_binary(value) ->
+          case safe_existing_atom(value) do
+            nil -> nil
+            atom_key -> Map.get(columns, atom_key)
+          end
+
+        _ ->
+          nil
+      end
+  end
+
+  defp normalize_row(row, columns, headers, row_keys, opts) when is_map(row) do
     headers
     |> Enum.with_index()
     |> Enum.reduce(%{}, fn {header, idx}, acc ->
       value = fetch_map_value_for_header(row, header, columns, idx)
-      Map.put(acc, Enum.at(row_keys, idx), sanitize_value(value))
+      Map.put(acc, Enum.at(row_keys, idx), format_export_value(value, idx, header, opts))
     end)
   end
 
-  defp normalize_row(row, _columns, _headers, row_keys) when is_tuple(row) do
+  defp normalize_row(row, _columns, headers, row_keys, opts) when is_tuple(row) do
     row
     |> Tuple.to_list()
-    |> normalize_row_from_list(row_keys)
+    |> normalize_row_from_list(row_keys, headers, opts)
   end
 
-  defp normalize_row(row, _columns, _headers, row_keys) when is_list(row) do
-    normalize_row_from_list(row, row_keys)
+  defp normalize_row(row, _columns, headers, row_keys, opts) when is_list(row) do
+    normalize_row_from_list(row, row_keys, headers, opts)
   end
 
-  defp normalize_row(value, _columns, _headers, []) do
-    %{"value" => sanitize_value(value)}
+  defp normalize_row(value, _columns, headers, [], opts) do
+    %{"value" => format_export_value(value, 0, List.first(headers), opts)}
   end
 
-  defp normalize_row(value, _columns, _headers, row_keys) do
+  defp normalize_row(value, _columns, headers, row_keys, opts) do
     row_key = List.first(row_keys)
 
     Map.new(row_keys, fn key ->
-      {key, if(key == row_key, do: sanitize_value(value), else: nil)}
+      {key,
+       if(key == row_key,
+         do: format_export_value(value, 0, List.first(headers), opts),
+         else: nil
+       )}
     end)
   end
 
-  defp normalize_row_from_list(list_row, row_keys) do
+  defp normalize_row_from_list(list_row, row_keys, headers, opts) do
     row_keys
-    |> Enum.zip(list_row)
-    |> Enum.into(%{}, fn {header, value} ->
-      {header, sanitize_value(value)}
+    |> Enum.with_index()
+    |> Enum.into(%{}, fn {header, idx} ->
+      value = Enum.at(list_row, idx)
+      {header, format_export_value(value, idx, Enum.at(headers, idx), opts)}
     end)
+  end
+
+  defp format_export_value(value, idx, header, opts) do
+    export_mode = Keyword.get(opts, :export_mode, :raw)
+    presentation_context = Keyword.get(opts, :presentation_context, %{})
+    row_column_defs = Keyword.get(opts, :row_column_defs, %{})
+
+    column_def =
+      Map.get(row_column_defs, idx) || Map.get(row_column_defs, to_string(header || ""))
+
+    value
+    |> Presentation.format_value(column_def, presentation_context, mode: export_mode)
+    |> sanitize_value()
   end
 
   defp fetch_map_value_for_header(row, header, columns, idx) do

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -257,6 +257,7 @@ defmodule SelectoComponents.Form do
       <script :type={Phoenix.LiveView.ColocatedHook} name=".ExportDownloads">
         export default {
           mounted() {
+            this.bindExportDownloadButtons();
             this.bindEmailExportButton();
             this.bindScheduledExportButton();
 
@@ -296,6 +297,7 @@ defmodule SelectoComponents.Form do
           },
 
           updated() {
+            this.bindExportDownloadButtons();
             this.bindEmailExportButton();
             this.bindScheduledExportButton();
           },
@@ -303,6 +305,10 @@ defmodule SelectoComponents.Form do
           destroyed() {
             if (this.emailExportCleanup) {
               this.emailExportCleanup();
+            }
+
+            if (this.exportDownloadCleanup) {
+              this.exportDownloadCleanup();
             }
 
             if (this.scheduledExportCleanup) {
@@ -327,12 +333,14 @@ defmodule SelectoComponents.Form do
 
               const recipients = document.getElementById(button.dataset.recipientsInput)?.value || "";
               const format = document.getElementById(button.dataset.formatInput)?.value || "csv";
+              const exportMode = document.getElementById(button.dataset.exportModeInput)?.value || "raw";
               const subject = document.getElementById(button.dataset.subjectInput)?.value || "";
               const body = document.getElementById(button.dataset.bodyInput)?.value || "";
 
               this.pushEvent("send_export_email", {
                 recipients,
                 format,
+                export_mode: exportMode,
                 subject,
                 body
               });
@@ -340,6 +348,39 @@ defmodule SelectoComponents.Form do
 
             button.addEventListener("click", handler);
             this.emailExportCleanup = () => button.removeEventListener("click", handler);
+          },
+
+          bindExportDownloadButtons() {
+            if (this.exportDownloadCleanup) {
+              this.exportDownloadCleanup();
+              this.exportDownloadCleanup = null;
+            }
+
+            const buttons = Array.from(this.el.querySelectorAll("[data-export-download-button='true']"));
+
+            if (buttons.length === 0) {
+              return;
+            }
+
+            const handlers = buttons.map((button) => {
+              const handler = (event) => {
+                event.preventDefault();
+
+                const exportMode = document.getElementById(button.dataset.exportModeInput)?.value || "raw";
+
+                this.pushEvent("export_data", {
+                  format: button.dataset.format || "csv",
+                  export_mode: exportMode
+                });
+              };
+
+              button.addEventListener("click", handler);
+              return { button, handler };
+            });
+
+            this.exportDownloadCleanup = () => {
+              handlers.forEach(({ button, handler }) => button.removeEventListener("click", handler));
+            };
           },
 
           bindScheduledExportButton() {

--- a/lib/selecto_components/form.ex
+++ b/lib/selecto_components/form.ex
@@ -70,6 +70,7 @@ defmodule SelectoComponents.Form do
         tree_builder_suffix: FilterRendering.hash_filter_structure(assigns.view_config.filters),
         detail_modal_visible: detail_modal_visible?(assigns),
         detail_modal_component: Map.get(assigns, :detail_modal_component),
+        presentation_context: Map.get(assigns, :presentation_context, %{}),
         form: to_form(%{}, as: "view_config")
       )
 

--- a/lib/selecto_components/form/event_handlers/export_operations.ex
+++ b/lib/selecto_components/form/event_handlers/export_operations.ex
@@ -24,14 +24,18 @@ defmodule SelectoComponents.Form.EventHandlers.ExportOperations do
       - `json`
       - `xlsx`
       """
-      def handle_event("export_data", %{"format" => format}, socket) do
+      def handle_event("export_data", %{"format" => format} = params, socket) do
         with_error_handling(socket, "export_data", fn ->
           query_results = socket.assigns[:query_results]
           view_mode = socket.assigns[:applied_view] || socket.assigns.view_config.view_mode
+          export_mode = normalize_export_mode(Map.get(params, "export_mode"))
 
           case Exporter.build(format, query_results,
                  view_mode: view_mode,
-                 view_config: socket.assigns[:view_config]
+                 view_config: socket.assigns[:view_config],
+                 selecto: socket.assigns[:selecto],
+                 presentation_context: socket.assigns[:presentation_context] || %{},
+                 export_mode: export_mode
                ) do
             {:ok, export} ->
               if byte_size(export.content) > @max_export_payload_bytes do
@@ -92,6 +96,9 @@ defmodule SelectoComponents.Form.EventHandlers.ExportOperations do
                      format: Map.get(params, "format", "csv"),
                      view_mode: view_mode,
                      view_config: socket.assigns[:view_config],
+                     selecto: socket.assigns[:selecto],
+                     presentation_context: socket.assigns[:presentation_context] || %{},
+                     export_mode: normalize_export_mode(Map.get(params, "export_mode")),
                      path: Map.get(socket.assigns, :path) || Map.get(socket.assigns, :my_path),
                      delivery_opts: [
                        current_user_id: Map.get(socket.assigns, :current_user_id),
@@ -198,6 +205,9 @@ defmodule SelectoComponents.Form.EventHandlers.ExportOperations do
 
         error.summary <> ": " <> error.user_message
       end
+
+      defp normalize_export_mode(value) when value in ["display", :display], do: :display
+      defp normalize_export_mode(_value), do: :raw
     end
   end
 end

--- a/lib/selecto_components/form/export_panel.ex
+++ b/lib/selecto_components/form/export_panel.ex
@@ -31,16 +31,25 @@ defmodule SelectoComponents.Form.ExportPanel do
       </p>
 
       <div class="flex flex-wrap gap-2">
-        <.sc_button type="button" phx-click="export_data" phx-value-format="csv" theme={@theme}>
+        <div class="flex items-center gap-2 pr-2">
+          <label class="text-sm font-medium" style="color: var(--sc-text-secondary);" for={"export-mode-#{@id}"}>
+            Export Mode
+          </label>
+          <select id={"export-mode-#{@id}"} class={Theme.slot(@theme, :select)}>
+            <option value="raw" selected>Raw</option>
+            <option value="display">Display</option>
+          </select>
+        </div>
+        <.sc_button type="button" data-export-download-button="true" data-format="csv" data-export-mode-input={"export-mode-#{@id}"} theme={@theme}>
           Download CSV
         </.sc_button>
-        <.sc_button type="button" phx-click="export_data" phx-value-format="tsv" theme={@theme}>
+        <.sc_button type="button" data-export-download-button="true" data-format="tsv" data-export-mode-input={"export-mode-#{@id}"} theme={@theme}>
           Download TSV
         </.sc_button>
-        <.sc_button type="button" phx-click="export_data" phx-value-format="json" theme={@theme}>
+        <.sc_button type="button" data-export-download-button="true" data-format="json" data-export-mode-input={"export-mode-#{@id}"} theme={@theme}>
           Download JSON
         </.sc_button>
-        <.sc_button type="button" phx-click="export_data" phx-value-format="xlsx" theme={@theme}>
+        <.sc_button type="button" data-export-download-button="true" data-format="xlsx" data-export-mode-input={"export-mode-#{@id}"} theme={@theme}>
           Download XLSX
         </.sc_button>
       </div>
@@ -98,6 +107,20 @@ defmodule SelectoComponents.Form.ExportPanel do
             <label
               class="text-sm font-medium"
               style="color: var(--sc-text-secondary);"
+              for={"export-email-mode-#{@id}"}
+            >
+              Export Mode
+            </label>
+            <select id={"export-email-mode-#{@id}"} class={Theme.slot(@theme, :select)}>
+              <option value="raw" selected>Raw</option>
+              <option value="display">Display</option>
+            </select>
+          </div>
+
+          <div class="space-y-2">
+            <label
+              class="text-sm font-medium"
+              style="color: var(--sc-text-secondary);"
               for={"export-email-subject-#{@id}"}
             >
               Subject
@@ -135,6 +158,7 @@ defmodule SelectoComponents.Form.ExportPanel do
             data-export-email-button="true"
             data-recipients-input={"export-email-recipients-#{@id}"}
             data-format-input={"export-email-format-#{@id}"}
+            data-export-mode-input={"export-email-mode-#{@id}"}
             data-subject-input={"export-email-subject-#{@id}"}
             data-body-input={"export-email-body-#{@id}"}
             class={Theme.slot(@theme, :button_primary) <> " px-4 py-2 text-sm shadow-sm"}

--- a/lib/selecto_components/form/filter_rendering.ex
+++ b/lib/selecto_components/form/filter_rendering.ex
@@ -16,6 +16,7 @@ defmodule SelectoComponents.Form.FilterRendering do
   use Phoenix.Component
   require Logger
 
+  alias SelectoComponents.Presentation
   alias SelectoComponents.SchemaUtils
 
   @identifier_regex ~r/^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$/
@@ -239,9 +240,11 @@ defmodule SelectoComponents.Form.FilterRendering do
                 type="date"
                 name={"filters[#{@uuid}][value_start]"}
                 value={
-                  format_datetime_value(
-                    @filter_value["value_start"],
-                    @column_def || @filter_def || :date
+                  filter_input_value(
+                    @filter_value,
+                    "value_start",
+                    @column_def || @filter_def || :date,
+                    @presentation_context
                   )
                 }
                 class="sc-input"
@@ -252,9 +255,11 @@ defmodule SelectoComponents.Form.FilterRendering do
                 type="date"
                 name={"filters[#{@uuid}][value_end]"}
                 value={
-                  format_datetime_value(
-                    @filter_value["value_end"],
-                    @column_def || @filter_def || :date
+                  filter_input_value(
+                    @filter_value,
+                    "value_end",
+                    @column_def || @filter_def || :date,
+                    @presentation_context
                   )
                 }
                 class="sc-input"
@@ -460,7 +465,12 @@ defmodule SelectoComponents.Form.FilterRendering do
               type="date"
               name={"filters[#{@uuid}][value]"}
               value={
-                format_datetime_value(@filter_value["value"], @column_def || @filter_def || :date)
+                filter_input_value(
+                  @filter_value,
+                  "value",
+                  @column_def || @filter_def || :date,
+                  @presentation_context
+                )
               }
               class="sc-input col-span-2"
             />
@@ -473,9 +483,11 @@ defmodule SelectoComponents.Form.FilterRendering do
               type={if @field_type == :date, do: "date", else: "datetime-local"}
               name={"filters[#{@uuid}][value]"}
               value={
-                format_datetime_value(
-                  @filter_value["value"],
-                  @column_def || @filter_def || @field_type
+                filter_input_value(
+                  @filter_value,
+                  "value",
+                  @column_def || @filter_def || @field_type,
+                  @presentation_context
                 )
               }
               class="sc-input col-span-2"
@@ -531,11 +543,33 @@ defmodule SelectoComponents.Form.FilterRendering do
       end
 
     between_start =
-      value_for(assigns.filter_value, "value_start") || value_for(assigns.filter_value, "value") ||
+      filter_input_value(
+        assigns.filter_value,
+        "value_start",
+        column_def,
+        assigns[:presentation_context]
+      ) ||
+        filter_input_value(
+          assigns.filter_value,
+          "value",
+          column_def,
+          assigns[:presentation_context]
+        ) ||
         ""
 
     between_end =
-      value_for(assigns.filter_value, "value_end") || value_for(assigns.filter_value, "value2") ||
+      filter_input_value(
+        assigns.filter_value,
+        "value_end",
+        column_def,
+        assigns[:presentation_context]
+      ) ||
+        filter_input_value(
+          assigns.filter_value,
+          "value2",
+          column_def,
+          assigns[:presentation_context]
+        ) ||
         ""
 
     assigns =
@@ -549,6 +583,7 @@ defmodule SelectoComponents.Form.FilterRendering do
         between_end: between_end,
         selected_in_values: selected_in_values(assigns.filter_value),
         pending_in_values: value_for(assigns.filter_value, "pending_values") || "",
+        presentation_context: Map.get(assigns, :presentation_context, %{}),
         ignore_case_checked:
           Map.get(assigns.filter_value, "ignore_case", "false") in [
             true,
@@ -731,7 +766,7 @@ defmodule SelectoComponents.Form.FilterRendering do
               <input
                 type="text"
                 name={"filters[#{@uuid}][value]"}
-                value={@filter_value["value"]}
+                value={filter_input_value(@filter_value, "value", @column_def || @filter_def, @presentation_context)}
                 placeholder="Enter IDs (comma-separated, e.g., 1,2,3)"
                 class="sc-input"
                 phx-debounce="300"
@@ -745,13 +780,13 @@ defmodule SelectoComponents.Form.FilterRendering do
             <%!-- Standard text input --%>
             <input
               type="text"
-              name={"filters[#{@uuid}][value]"}
-              value={@filter_value["value"]}
-              placeholder="Enter value..."
-              class="sc-input col-span-2"
-              phx-debounce="300"
-              disabled={@current_comp in ["IS NULL", "IS NOT NULL"]}
-            />
+                name={"filters[#{@uuid}][value]"}
+                value={filter_input_value(@filter_value, "value", @column_def || @filter_def, @presentation_context)}
+                placeholder="Enter value..."
+                class="sc-input col-span-2"
+                phx-debounce="300"
+                disabled={@current_comp in ["IS NULL", "IS NOT NULL"]}
+              />
         <% end %>
 
         <%= if @is_text_field and @current_comp in ["=", "STARTS"] do %>
@@ -1097,6 +1132,69 @@ defmodule SelectoComponents.Form.FilterRendering do
   end
 
   def format_datetime_value(value, _type), do: value
+
+  defp filter_input_value(filter_value, key, field_conf, presentation_context)
+       when is_map(filter_value) do
+    display_key = "display_#{key}"
+
+    cond do
+      is_binary(Map.get(filter_value, display_key)) ->
+        Map.get(filter_value, display_key)
+
+      Selecto.Presentation.measurement?(field_conf) ->
+        Presentation.format_cell(Map.get(filter_value, key), field_conf, presentation_context,
+          show_unit: false
+        )
+
+      Selecto.Presentation.temporal?(field_conf) or Selecto.Temporal.date_like?(field_conf) ->
+        temporal_input_value(Map.get(filter_value, key), field_conf, presentation_context)
+
+      true ->
+        value_for(filter_value, key)
+    end
+  end
+
+  defp filter_input_value(_filter_value, _key, _field_conf, _presentation_context), do: nil
+
+  defp temporal_input_value(value, field_conf, presentation_context) do
+    timezone =
+      presentation_context
+      |> Presentation.resolve_context()
+      |> Map.get(:timezone, "Etc/UTC")
+
+    field_conf
+    |> Selecto.Temporal.to_display_temporal(value)
+    |> maybe_shift_temporal_display(field_conf, timezone)
+    |> case do
+      %Date{} = date ->
+        format_datetime_value(Date.to_iso8601(date), :date)
+
+      %NaiveDateTime{} = dt ->
+        format_datetime_value(NaiveDateTime.to_iso8601(dt), :naive_datetime)
+
+      %DateTime{} = dt ->
+        format_datetime_value(DateTime.to_iso8601(dt), :utc_datetime)
+
+      other ->
+        format_datetime_value(
+          other,
+          Selecto.Temporal.date_like_type(field_conf) || Map.get(field_conf, :type)
+        )
+    end
+  end
+
+  defp maybe_shift_temporal_display(%DateTime{} = datetime, field_conf, timezone) do
+    if Selecto.Presentation.temporal_kind(field_conf) == :instant do
+      case DateTime.shift_zone(datetime, timezone) do
+        {:ok, shifted} -> shifted
+        _ -> datetime
+      end
+    else
+      datetime
+    end
+  end
+
+  defp maybe_shift_temporal_display(value, _field_conf, _timezone), do: value
 
   @doc """
   Check if a value is a date shortcut (today, this_week, last_month, etc.).

--- a/lib/selecto_components/form/params_state.ex
+++ b/lib/selecto_components/form/params_state.ex
@@ -20,6 +20,7 @@ defmodule SelectoComponents.Form.ParamsState do
   alias SelectoComponents.EnhancedTable.Sorting
   alias SelectoComponents.SafeAtom
   alias SelectoComponents.QueryResults
+  alias SelectoComponents.Presentation
   alias SelectoComponents.Views.Runtime, as: ViewRuntime
   require Logger
 
@@ -589,6 +590,11 @@ defmodule SelectoComponents.Form.ParamsState do
             execution_error: nil
           )
 
+        presentation_context =
+          socket.assigns
+          |> Map.get(:presentation_context, %{})
+          |> Presentation.resolve_context()
+
         old_selecto = socket.assigns.selecto
 
         selecto =
@@ -791,6 +797,7 @@ defmodule SelectoComponents.Form.ParamsState do
                 selecto: selecto,
                 columns: columns_list,
                 field_filters: Selecto.filters(selecto),
+                presentation_context: presentation_context,
                 query_results: {normalized_rows, columns, aliases},
                 used_params: params,
                 applied_view: get_map_value(params, :view_mode),
@@ -839,6 +846,7 @@ defmodule SelectoComponents.Form.ParamsState do
               selecto: selecto,
               columns: columns_list,
               field_filters: Selecto.filters(selecto),
+              presentation_context: presentation_context,
               query_results: nil,
               used_params: params,
               applied_view: get_map_value(params, :view_mode),
@@ -881,6 +889,7 @@ defmodule SelectoComponents.Form.ParamsState do
               selecto: selecto,
               columns: columns_list,
               field_filters: Selecto.filters(selecto),
+              presentation_context: presentation_context,
               query_results: nil,
               used_params: params,
               applied_view: get_map_value(params, :view_mode),

--- a/lib/selecto_components/form/params_state.ex
+++ b/lib/selecto_components/form/params_state.ex
@@ -581,8 +581,6 @@ defmodule SelectoComponents.Form.ParamsState do
   def view_from_params(params, socket) do
     result_socket =
       try do
-        params = canonicalize_form_params(params)
-
         socket =
           Phoenix.Component.assign(socket,
             query_results: nil,
@@ -594,6 +592,9 @@ defmodule SelectoComponents.Form.ParamsState do
           socket.assigns
           |> Map.get(:presentation_context, %{})
           |> Presentation.resolve_context()
+
+        params = canonicalize_form_params(params, socket.assigns[:selecto], presentation_context)
+        params = put_runtime_presentation_context(params, presentation_context)
 
         old_selecto = socket.assigns.selecto
 
@@ -799,7 +800,7 @@ defmodule SelectoComponents.Form.ParamsState do
                 field_filters: Selecto.filters(selecto),
                 presentation_context: presentation_context,
                 query_results: {normalized_rows, columns, aliases},
-                used_params: params,
+                used_params: drop_runtime_only_params(params),
                 applied_view: get_map_value(params, :view_mode),
                 view_meta: view_meta,
                 detail_page_cache: detail_cache_assignment,
@@ -848,7 +849,7 @@ defmodule SelectoComponents.Form.ParamsState do
               field_filters: Selecto.filters(selecto),
               presentation_context: presentation_context,
               query_results: nil,
-              used_params: params,
+              used_params: drop_runtime_only_params(params),
               applied_view: get_map_value(params, :view_mode),
               view_meta: view_meta,
               detail_page_cache:
@@ -891,7 +892,7 @@ defmodule SelectoComponents.Form.ParamsState do
               field_filters: Selecto.filters(selecto),
               presentation_context: presentation_context,
               query_results: nil,
-              used_params: params,
+              used_params: drop_runtime_only_params(params),
               applied_view: get_map_value(params, :view_mode),
               view_meta: view_meta,
               detail_page_cache:
@@ -927,7 +928,7 @@ defmodule SelectoComponents.Form.ParamsState do
 
           Phoenix.Component.assign(socket,
             query_results: nil,
-            used_params: params,
+            used_params: drop_runtime_only_params(params),
             applied_view: view_mode_value(params, socket.assigns[:applied_view]),
             executed: false,
             execution_error: sanitized_error,
@@ -940,7 +941,7 @@ defmodule SelectoComponents.Form.ParamsState do
         :exit, reason ->
           Phoenix.Component.assign(socket,
             query_results: nil,
-            used_params: params,
+            used_params: drop_runtime_only_params(params),
             applied_view: view_mode_value(params, socket.assigns[:applied_view]),
             executed: false,
             execution_error:
@@ -1432,7 +1433,13 @@ defmodule SelectoComponents.Form.ParamsState do
   Build view_config from URL params, updating full state including view-specific configs.
   """
   def params_to_state(params, socket) do
-    params = canonicalize_form_params(params)
+    params =
+      canonicalize_form_params(
+        params,
+        socket.assigns[:selecto],
+        socket.assigns[:presentation_context]
+      )
+
     filters = view_filter_process(params, "filters")
     existing_config = socket.assigns[:view_config] || %{}
 
@@ -1470,7 +1477,13 @@ defmodule SelectoComponents.Form.ParamsState do
   so every view can be reconstructed from the browser state in one pass.
   """
   def form_params_to_state(params, socket) do
-    params = canonicalize_form_params(params)
+    params =
+      canonicalize_form_params(
+        params,
+        socket.assigns[:selecto],
+        socket.assigns[:presentation_context]
+      )
+
     existing_config = socket.assigns[:view_config] || %{}
     stale_submit? = stale_form_submit?(params, socket)
     filters = submitted_filters_state(params, existing_config, stale_submit?)
@@ -1936,8 +1949,13 @@ defmodule SelectoComponents.Form.ParamsState do
   defp detail_param_atom("count_mode"), do: :count_mode
   defp detail_param_atom("prevent_denormalization"), do: :prevent_denormalization
 
-  def canonicalize_form_params(params) when is_map(params) do
-    params = merge_promoted_filter_params(params)
+  def canonicalize_form_params(params, selecto \\ nil, presentation_context \\ %{})
+
+  def canonicalize_form_params(params, selecto, presentation_context) when is_map(params) do
+    params =
+      params
+      |> merge_promoted_filter_params()
+      |> canonicalize_filter_params(selecto, presentation_context)
 
     row_click_action =
       normalize_optional_scalar(get_map_value(params, "row_click_action_ui")) ||
@@ -1950,7 +1968,7 @@ defmodule SelectoComponents.Form.ParamsState do
     end
   end
 
-  def canonicalize_form_params(params), do: params
+  def canonicalize_form_params(params, _selecto, _presentation_context), do: params
 
   defp merge_promoted_filter_params(params) when not is_map(params), do: params
 
@@ -2009,6 +2027,421 @@ defmodule SelectoComponents.Form.ParamsState do
       )
     else
       promoted_values
+    end
+  end
+
+  defp canonicalize_filter_params(params, nil, _presentation_context), do: params
+
+  defp canonicalize_filter_params(params, selecto, presentation_context) when is_map(params) do
+    if valid_selecto_for_filter_canonicalization?(selecto) do
+      case Map.get(params, "filters") do
+        filters when is_map(filters) ->
+          normalized_filters =
+            Enum.into(filters, %{}, fn {uuid, filter} ->
+              {uuid, canonicalize_filter_map(filter, selecto, presentation_context)}
+            end)
+
+          Map.put(params, "filters", normalized_filters)
+
+        _ ->
+          params
+      end
+    else
+      params
+    end
+  end
+
+  defp valid_selecto_for_filter_canonicalization?(%Selecto{config: config}) when is_map(config),
+    do: true
+
+  defp valid_selecto_for_filter_canonicalization?(_), do: false
+
+  defp canonicalize_filter_map(filter, _selecto, _presentation_context) when not is_map(filter),
+    do: filter
+
+  defp canonicalize_filter_map(filter, selecto, presentation_context) do
+    filter_id = get_map_value(filter, "filter")
+    column = resolve_filter_column(selecto, filter_id)
+
+    cond do
+      is_nil(column) ->
+        filter
+
+      Selecto.Presentation.measurement?(column) ->
+        canonicalize_measurement_filter(filter, column, presentation_context)
+
+      Selecto.Presentation.temporal?(column) or Selecto.Temporal.date_like?(column) ->
+        canonicalize_temporal_filter(filter, column, presentation_context)
+
+      locale_numeric_column?(column) ->
+        canonicalize_numeric_filter(filter, presentation_context)
+
+      true ->
+        filter
+    end
+  end
+
+  defp resolve_filter_column(nil, _filter_id), do: nil
+  defp resolve_filter_column(_selecto, nil), do: nil
+
+  defp resolve_filter_column(selecto, filter_id) do
+    Selecto.columns(selecto)[filter_id] ||
+      Enum.find_value(Selecto.columns(selecto), fn {_key, col} ->
+        if col.colid == filter_id or to_string(col.colid) == filter_id or col.name == filter_id,
+          do: col,
+          else: nil
+      end) || Selecto.field(selecto, filter_id)
+  end
+
+  defp canonicalize_measurement_filter(filter, column, presentation_context) do
+    display_unit = Presentation.display_unit(column, presentation_context)
+    canonical_unit = Selecto.Presentation.canonical_unit(column)
+    comp = normalize_filter_comp(filter)
+
+    filter
+    |> maybe_put_display_value("value")
+    |> maybe_put_display_value("value_start")
+    |> maybe_put_display_value("value_end")
+    |> maybe_put_display_value("value2")
+    |> maybe_canonicalize_measurement_key(
+      "value",
+      comp,
+      display_unit,
+      canonical_unit,
+      presentation_context
+    )
+    |> maybe_canonicalize_measurement_key(
+      "value_start",
+      comp,
+      display_unit,
+      canonical_unit,
+      presentation_context
+    )
+    |> maybe_canonicalize_measurement_key(
+      "value_end",
+      comp,
+      display_unit,
+      canonical_unit,
+      presentation_context
+    )
+    |> maybe_canonicalize_measurement_key(
+      "value2",
+      comp,
+      display_unit,
+      canonical_unit,
+      presentation_context
+    )
+  end
+
+  defp maybe_canonicalize_measurement_key(
+         filter,
+         _key,
+         comp,
+         _display_unit,
+         _canonical_unit,
+         _presentation_context
+       )
+       when comp in [
+              "SHORTCUT",
+              "RELATIVE",
+              "IS NULL",
+              "IS NOT NULL",
+              "WEEKDAY",
+              "WEEKDAY_SUN1",
+              "WEEK_OF_YEAR",
+              "MONTH_OF_YEAR",
+              "DAY_OF_MONTH",
+              "HOUR_OF_DAY"
+            ] do
+    filter
+  end
+
+  defp maybe_canonicalize_measurement_key(
+         filter,
+         key,
+         _comp,
+         display_unit,
+         canonical_unit,
+         presentation_context
+       ) do
+    case convert_measurement_filter_value(
+           Map.get(filter, key),
+           display_unit,
+           canonical_unit,
+           presentation_context
+         ) do
+      {:ok, converted} -> Map.put(filter, key, converted)
+      :skip -> filter
+    end
+  end
+
+  defp convert_measurement_filter_value(
+         value,
+         _display_unit,
+         _canonical_unit,
+         _presentation_context
+       )
+       when value in [nil, ""],
+       do: :skip
+
+  defp convert_measurement_filter_value(value, display_unit, canonical_unit, presentation_context) do
+    case split_measurement_value(value) do
+      {numeric, suffix} ->
+        with number when not is_nil(number) <-
+               Presentation.parse_number(numeric, presentation_context),
+             true <- suffix in [nil, "", measurement_unit_label(display_unit)],
+             converted when not is_nil(converted) <-
+               maybe_convert_measurement_to_canonical(number, display_unit, canonical_unit) do
+          {:ok, float_to_filter_string(converted)}
+        else
+          _ -> :skip
+        end
+    end
+  end
+
+  defp split_measurement_value(value) when is_binary(value) do
+    case Regex.run(~r/^\s*([-+]?[0-9][0-9\s.,'’  ]*[0-9]|[-+]?[0-9])\s*([^0-9\s].*)?\s*$/u, value) do
+      [_, number] -> {number, nil}
+      [_, number, suffix] -> {number, String.trim(suffix)}
+      _ -> {String.trim(value), nil}
+    end
+  end
+
+  defp split_measurement_value(value), do: {to_string(value), nil}
+
+  defp float_to_filter_string(value) when is_float(value) do
+    value
+    |> Float.round(12)
+    |> :erlang.float_to_binary(decimals: 12)
+    |> String.trim_trailing("0")
+    |> String.trim_trailing(".")
+  end
+
+  defp measurement_unit_label(unit) do
+    case Presentation.display_unit_label(
+           %{presentation: %{default_unit: unit, canonical_unit: unit}},
+           %{}
+         ) do
+      nil -> nil
+      label -> String.trim(label)
+    end
+  end
+
+  defp measurement_to_canonical(value, :fahrenheit, :celsius), do: (value - 32) * 5 / 9
+  defp measurement_to_canonical(value, :kelvin, :celsius), do: value - 273.15
+  defp measurement_to_canonical(value, :celsius, :fahrenheit), do: value * 9 / 5 + 32
+  defp measurement_to_canonical(value, :celsius, :kelvin), do: value + 273.15
+
+  defp measurement_to_canonical(value, display_unit, canonical_unit)
+       when display_unit == canonical_unit, do: value
+
+  defp measurement_to_canonical(value, display_unit, canonical_unit) do
+    with {:ok, display_factor} <- measurement_factor(display_unit),
+         {:ok, canonical_factor} <- measurement_factor(canonical_unit) do
+      value * display_factor / canonical_factor
+    else
+      _ -> nil
+    end
+  end
+
+  defp measurement_factor(:millimeter), do: {:ok, 0.001}
+  defp measurement_factor(:centimeter), do: {:ok, 0.01}
+  defp measurement_factor(:meter), do: {:ok, 1.0}
+  defp measurement_factor(:kilometer), do: {:ok, 1000.0}
+  defp measurement_factor(:inch), do: {:ok, 0.0254}
+  defp measurement_factor(:foot), do: {:ok, 0.3048}
+  defp measurement_factor(:yard), do: {:ok, 0.9144}
+  defp measurement_factor(:mile), do: {:ok, 1609.344}
+  defp measurement_factor(:gram), do: {:ok, 1.0}
+  defp measurement_factor(:kilogram), do: {:ok, 1000.0}
+  defp measurement_factor(:ounce), do: {:ok, 28.349523125}
+  defp measurement_factor(:pound), do: {:ok, 453.59237}
+  defp measurement_factor(:milliliter), do: {:ok, 0.001}
+  defp measurement_factor(:liter), do: {:ok, 1.0}
+  defp measurement_factor(:fluid_ounce), do: {:ok, 0.0295735295625}
+  defp measurement_factor(:gallon), do: {:ok, 3.785411784}
+  defp measurement_factor(:square_meter), do: {:ok, 1.0}
+  defp measurement_factor(:square_foot), do: {:ok, 0.09290304}
+  defp measurement_factor(:acre), do: {:ok, 4046.8564224}
+  defp measurement_factor(:hectare), do: {:ok, 10000.0}
+  defp measurement_factor(:meter_per_second), do: {:ok, 1.0}
+  defp measurement_factor(:kilometer_per_hour), do: {:ok, 0.2777777778}
+  defp measurement_factor(:mile_per_hour), do: {:ok, 0.44704}
+  defp measurement_factor(_unit), do: :error
+
+  defp maybe_convert_measurement_to_canonical(value, display_unit, canonical_unit)
+       when is_nil(display_unit) or is_nil(canonical_unit) or display_unit == canonical_unit,
+       do: value
+
+  defp maybe_convert_measurement_to_canonical(value, display_unit, canonical_unit),
+    do: measurement_to_canonical(value, display_unit, canonical_unit)
+
+  defp canonicalize_numeric_filter(filter, presentation_context) do
+    comp = normalize_filter_comp(filter)
+
+    filter
+    |> maybe_put_display_value("value")
+    |> maybe_put_display_value("value_start")
+    |> maybe_put_display_value("value_end")
+    |> maybe_put_display_value("value2")
+    |> maybe_canonicalize_numeric_key("value", comp, presentation_context)
+    |> maybe_canonicalize_numeric_key("value_start", comp, presentation_context)
+    |> maybe_canonicalize_numeric_key("value_end", comp, presentation_context)
+    |> maybe_canonicalize_numeric_key("value2", comp, presentation_context)
+  end
+
+  defp maybe_canonicalize_numeric_key(filter, _key, comp, _presentation_context)
+       when comp in [
+              "SHORTCUT",
+              "RELATIVE",
+              "IS NULL",
+              "IS NOT NULL",
+              "WEEKDAY",
+              "WEEKDAY_SUN1",
+              "WEEK_OF_YEAR",
+              "MONTH_OF_YEAR",
+              "DAY_OF_MONTH",
+              "HOUR_OF_DAY"
+            ] do
+    filter
+  end
+
+  defp maybe_canonicalize_numeric_key(filter, key, _comp, presentation_context) do
+    case Map.get(filter, key) do
+      value when value in [nil, ""] ->
+        filter
+
+      value ->
+        case Presentation.parse_number(value, presentation_context) do
+          number when is_float(number) -> Map.put(filter, key, float_to_filter_string(number))
+          _ -> filter
+        end
+    end
+  end
+
+  defp locale_numeric_column?(column) when is_map(column) do
+    normalized_type = Selecto.Temporal.date_like_type(column) || Map.get(column, :type)
+    normalized_type in [:integer, :float, :decimal]
+  end
+
+  defp locale_numeric_column?(_column), do: false
+
+  defp canonicalize_temporal_filter(filter, column, presentation_context) do
+    comp = normalize_filter_comp(filter)
+    timezone = presentation_timezone(presentation_context)
+
+    filter
+    |> maybe_put_display_value("value")
+    |> maybe_put_display_value("value_start")
+    |> maybe_put_display_value("value_end")
+    |> maybe_put_display_value("value2")
+    |> maybe_canonicalize_temporal_key("value", comp, column, timezone)
+    |> maybe_canonicalize_temporal_key("value_start", comp, column, timezone)
+    |> maybe_canonicalize_temporal_key("value_end", comp, column, timezone)
+    |> maybe_canonicalize_temporal_key("value2", comp, column, timezone)
+  end
+
+  defp maybe_canonicalize_temporal_key(filter, _key, comp, _column, _timezone)
+       when comp in [
+              "SHORTCUT",
+              "RELATIVE",
+              "WEEKDAY",
+              "WEEKDAY_SUN1",
+              "WEEK_OF_YEAR",
+              "MONTH_OF_YEAR",
+              "DAY_OF_MONTH",
+              "HOUR_OF_DAY",
+              "DATE=",
+              "DATE!=",
+              "DATE_BETWEEN"
+            ] do
+    filter
+  end
+
+  defp maybe_canonicalize_temporal_key(filter, key, _comp, column, timezone) do
+    case local_input_to_utc_string(Map.get(filter, key), column, timezone) do
+      nil -> filter
+      converted -> Map.put(filter, key, converted)
+    end
+  end
+
+  defp local_input_to_utc_string(value, column, timezone) when is_binary(value) do
+    if Selecto.Presentation.temporal_kind(column) == :instant do
+      trimmed = String.trim(value)
+
+      cond do
+        trimmed == "" ->
+          nil
+
+        match?({:ok, _}, NaiveDateTime.from_iso8601(trimmed)) ->
+          {:ok, naive} = NaiveDateTime.from_iso8601(trimmed)
+          timezone_naive_to_utc_string(naive, timezone)
+
+        match?({:ok, _}, NaiveDateTime.from_iso8601(trimmed <> ":00")) ->
+          {:ok, naive} = NaiveDateTime.from_iso8601(trimmed <> ":00")
+          timezone_naive_to_utc_string(naive, timezone)
+
+        String.contains?(trimmed, " ") and
+            match?({:ok, _}, NaiveDateTime.from_iso8601(String.replace(trimmed, " ", "T"))) ->
+          {:ok, naive} = trimmed |> String.replace(" ", "T") |> NaiveDateTime.from_iso8601()
+          timezone_naive_to_utc_string(naive, timezone)
+
+        String.contains?(trimmed, " ") and
+            match?(
+              {:ok, _},
+              NaiveDateTime.from_iso8601(String.replace(trimmed, " ", "T") <> ":00")
+            ) ->
+          {:ok, naive} =
+            trimmed
+            |> String.replace(" ", "T")
+            |> Kernel.<>(":00")
+            |> NaiveDateTime.from_iso8601()
+
+          timezone_naive_to_utc_string(naive, timezone)
+
+        true ->
+          nil
+      end
+    end
+  end
+
+  defp local_input_to_utc_string(_value, _column, _timezone), do: nil
+
+  defp timezone_naive_to_utc_string(naive, timezone) do
+    case DateTime.from_naive(naive, timezone) do
+      {:ok, datetime} ->
+        datetime
+        |> DateTime.shift_zone!("Etc/UTC")
+        |> DateTime.to_iso8601()
+
+      {:ambiguous, datetime, _other} ->
+        datetime
+        |> DateTime.shift_zone!("Etc/UTC")
+        |> DateTime.to_iso8601()
+
+      _ ->
+        nil
+    end
+  end
+
+  defp presentation_timezone(context) do
+    context
+    |> Presentation.resolve_context()
+    |> Map.get(:timezone, "Etc/UTC")
+  end
+
+  defp normalize_filter_comp(filter) do
+    filter
+    |> get_map_value("comp", "=")
+    |> to_string()
+    |> String.trim()
+    |> String.upcase()
+  end
+
+  defp maybe_put_display_value(filter, key) do
+    case Map.get(filter, key) do
+      nil -> filter
+      value -> Map.put_new(filter, "display_#{key}", value)
     end
   end
 
@@ -2766,11 +3199,25 @@ defmodule SelectoComponents.Form.ParamsState do
 
   defp sort_index_for_compaction(_value), do: 0
 
+  defp put_runtime_presentation_context(params, presentation_context) when is_map(params) do
+    Map.put(params, "_presentation_context", presentation_context || %{})
+  end
+
+  defp put_runtime_presentation_context(params, _presentation_context), do: params
+
+  defp drop_runtime_only_params(params) when is_map(params) do
+    Map.delete(params, "_presentation_context")
+  end
+
+  defp drop_runtime_only_params(params), do: params
+
   defp drop_unused_form_params(params) when is_map(params) do
     params
     |> Enum.reject(fn {key, _value} ->
       key_str = to_string(key)
-      String.starts_with?(key_str, "_unused_") or key_str in ["_target", "save_as"]
+
+      String.starts_with?(key_str, "_unused_") or
+        key_str in ["_target", "save_as", "_presentation_context"]
     end)
     |> Enum.into(%{}, fn {key, value} -> {key, drop_unused_form_params(value)} end)
   end

--- a/lib/selecto_components/presentation.ex
+++ b/lib/selecto_components/presentation.ex
@@ -206,19 +206,28 @@ defmodule SelectoComponents.Presentation do
     local_value = temporal_to_display(value, column, temporal_kind, timezone)
     include_timezone? = Keyword.get(opts, :include_timezone, false)
 
-    case local_value do
-      %Date{} = date ->
-        Date.to_iso8601(date)
+    case format_temporal_with_adapter(local_value, context, column, presentation, opts) do
+      {:ok, formatted} when is_binary(formatted) ->
+        formatted
 
-      %NaiveDateTime{} = naive ->
-        Calendar.strftime(naive, "%Y-%m-%d %H:%M")
+      _ ->
+        case local_value do
+          %Date{} = date ->
+            Date.to_iso8601(date)
 
-      %DateTime{} = datetime ->
-        formatted = Calendar.strftime(datetime, "%Y-%m-%d %H:%M")
-        if include_timezone?, do: formatted <> " " <> timezone_label(datetime), else: formatted
+          %NaiveDateTime{} = naive ->
+            Calendar.strftime(naive, "%Y-%m-%d %H:%M")
 
-      other ->
-        value_to_string(other)
+          %DateTime{} = datetime ->
+            formatted = Calendar.strftime(datetime, "%Y-%m-%d %H:%M")
+
+            if include_timezone?,
+              do: formatted <> " " <> timezone_label(datetime),
+              else: formatted
+
+          other ->
+            value_to_string(other)
+        end
     end
   end
 
@@ -358,6 +367,27 @@ defmodule SelectoComponents.Presentation do
           adapter.format_number(value, context,
             digits: digits,
             presentation: presentation,
+            locale_adapter_options: Map.get(context, :locale_adapter_options, %{})
+          )
+        else
+          :error
+        end
+
+      _ ->
+        :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp format_temporal_with_adapter(value, context, column, presentation, opts) do
+    case Map.get(context, :locale_adapter) do
+      adapter when is_atom(adapter) ->
+        if function_exported?(adapter, :format_temporal, 3) do
+          adapter.format_temporal(value, context,
+            column: column,
+            presentation: presentation,
+            include_timezone: Keyword.get(opts, :include_timezone, false),
             locale_adapter_options: Map.get(context, :locale_adapter_options, %{})
           )
         else

--- a/lib/selecto_components/presentation.ex
+++ b/lib/selecto_components/presentation.ex
@@ -1,0 +1,385 @@
+defmodule SelectoComponents.Presentation do
+  @moduledoc false
+
+  alias Decimal, as: D
+
+  @unit_system_defaults %{
+    metric: %{
+      temperature: :celsius,
+      length: :meter,
+      distance: :kilometer,
+      mass: :kilogram,
+      volume: :liter,
+      area: :square_meter,
+      speed: :kilometer_per_hour
+    },
+    us_customary: %{
+      temperature: :fahrenheit,
+      length: :foot,
+      distance: :mile,
+      mass: :pound,
+      volume: :gallon,
+      area: :square_foot,
+      speed: :mile_per_hour
+    }
+  }
+
+  @unit_labels %{
+    celsius: "C",
+    fahrenheit: "F",
+    kelvin: "K",
+    millimeter: "mm",
+    centimeter: "cm",
+    meter: "m",
+    kilometer: "km",
+    inch: "in",
+    foot: "ft",
+    yard: "yd",
+    mile: "mi",
+    gram: "g",
+    kilogram: "kg",
+    ounce: "oz",
+    pound: "lb",
+    milliliter: "mL",
+    liter: "L",
+    fluid_ounce: "fl oz",
+    gallon: "gal",
+    square_meter: "m2",
+    square_foot: "ft2",
+    acre: "acre",
+    hectare: "ha",
+    meter_per_second: "m/s",
+    kilometer_per_hour: "km/h",
+    mile_per_hour: "mph"
+  }
+
+  @spec resolve_context(map() | nil) :: map()
+  def resolve_context(context) when is_map(context) do
+    %{
+      locale: normalize_locale(Map.get(context, :locale) || Map.get(context, "locale")),
+      timezone: normalize_timezone(Map.get(context, :timezone) || Map.get(context, "timezone")),
+      unit_system:
+        normalize_unit_system(Map.get(context, :unit_system) || Map.get(context, "unit_system")),
+      unit_overrides:
+        normalize_unit_overrides(
+          Map.get(context, :unit_overrides) || Map.get(context, "unit_overrides", %{})
+        ),
+      conventions: Map.get(context, :conventions) || Map.get(context, "conventions") || %{}
+    }
+  end
+
+  def resolve_context(_context) do
+    %{
+      locale: nil,
+      timezone: "Etc/UTC",
+      unit_system: :metric,
+      unit_overrides: %{},
+      conventions: %{}
+    }
+  end
+
+  @spec format_value(term(), map() | nil, map() | nil, keyword()) :: term()
+  def format_value(value, column, context, opts \\ [])
+
+  def format_value(value, _column, _context, _opts) when value in [nil, ""], do: value
+
+  def format_value(value, column, context, opts) do
+    context = resolve_context(context)
+    mode = Keyword.get(opts, :mode, :display)
+
+    if mode == :raw do
+      value
+    else
+      do_format_value(value, column, context, opts)
+    end
+  end
+
+  @spec format_cell(term(), map() | nil, map() | nil, keyword()) :: String.t()
+  def format_cell(value, column, context, opts \\ []) do
+    formatted = format_value(value, column, context, opts)
+    value_to_string(formatted)
+  end
+
+  @spec display_unit(map() | nil, map() | nil) :: atom() | String.t() | nil
+  def display_unit(column, context) do
+    presentation = presentation(column)
+    context = resolve_context(context)
+    quantity = Map.get(presentation || %{}, :quantity)
+    overrides = Map.get(context, :unit_overrides, %{})
+
+    cond do
+      is_nil(presentation) ->
+        nil
+
+      quantity && Map.has_key?(overrides, quantity) ->
+        Map.get(overrides, quantity)
+
+      quantity && Map.has_key?(@unit_system_defaults[context.unit_system] || %{}, quantity) ->
+        Map.get(@unit_system_defaults[context.unit_system] || %{}, quantity)
+
+      true ->
+        Map.get(presentation, :default_unit) || Map.get(presentation, :canonical_unit)
+    end
+  end
+
+  @spec display_unit_label(map() | nil, map() | nil) :: String.t() | nil
+  def display_unit_label(column, context) do
+    case display_unit(column, context) do
+      nil -> nil
+      unit -> Map.get(@unit_labels, unit, to_string(unit))
+    end
+  end
+
+  defp do_format_value(value, column, context, opts) do
+    presentation = presentation(column)
+
+    cond do
+      match?(%{semantic_type: :measurement}, presentation) ->
+        format_measurement(value, presentation, context, opts)
+
+      match?(%{semantic_type: :temporal}, presentation) ->
+        format_temporal(value, column, presentation, context, opts)
+
+      true ->
+        format_plain_value(value, context, opts)
+    end
+  end
+
+  defp format_measurement(value, presentation, context, opts) do
+    canonical_unit = Map.get(presentation, :canonical_unit)
+    target_unit = display_unit(%{presentation: presentation}, context)
+    converted_value = convert_measurement(value, canonical_unit, target_unit)
+    show_unit? = Keyword.get(opts, :show_unit, true)
+    text_value = format_number(converted_value, presentation, context)
+
+    if show_unit? and target_unit do
+      text_value <> " " <> Map.get(@unit_labels, target_unit, to_string(target_unit))
+    else
+      text_value
+    end
+  end
+
+  defp format_temporal(value, column, presentation, context, opts) do
+    timezone = Map.get(context, :timezone, "Etc/UTC")
+    temporal_kind = Map.get(presentation, :temporal_kind)
+    local_value = temporal_to_display(value, column, temporal_kind, timezone)
+    include_timezone? = Keyword.get(opts, :include_timezone, false)
+
+    case local_value do
+      %Date{} = date ->
+        Date.to_iso8601(date)
+
+      %NaiveDateTime{} = naive ->
+        Calendar.strftime(naive, "%Y-%m-%d %H:%M")
+
+      %DateTime{} = datetime ->
+        formatted = Calendar.strftime(datetime, "%Y-%m-%d %H:%M")
+        if include_timezone?, do: formatted <> " " <> timezone_label(datetime), else: formatted
+
+      other ->
+        value_to_string(other)
+    end
+  end
+
+  defp format_plain_value(value, _context, _opts) do
+    value_to_string(value)
+  end
+
+  defp presentation(%{presentation: presentation}) when is_map(presentation), do: presentation
+  defp presentation(column) when is_map(column), do: Selecto.Presentation.presentation(column)
+  defp presentation(_column), do: nil
+
+  defp normalize_locale(nil), do: nil
+
+  defp normalize_locale(locale) when is_binary(locale) do
+    case String.trim(locale) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_locale(_locale), do: nil
+
+  defp normalize_timezone(nil), do: "Etc/UTC"
+
+  defp normalize_timezone(timezone) when is_binary(timezone) do
+    case String.trim(timezone) do
+      "" -> "Etc/UTC"
+      trimmed -> trimmed
+    end
+  end
+
+  defp normalize_timezone(_timezone), do: "Etc/UTC"
+
+  defp normalize_unit_system(value) when value in [:metric, :us_customary], do: value
+  defp normalize_unit_system("us"), do: :us_customary
+  defp normalize_unit_system("us_customary"), do: :us_customary
+  defp normalize_unit_system("metric"), do: :metric
+  defp normalize_unit_system(_value), do: :metric
+
+  defp normalize_unit_overrides(overrides) when is_map(overrides) do
+    Map.new(overrides, fn {quantity, unit} ->
+      {normalize_override_key(quantity), normalize_override_unit(unit)}
+    end)
+  end
+
+  defp normalize_unit_overrides(_), do: %{}
+
+  defp normalize_override_key(value) when is_atom(value), do: value
+
+  defp normalize_override_key(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace(~r/[\s-]+/u, "_")
+    |> safe_existing_atom_or_string()
+  end
+
+  defp normalize_override_key(value), do: value
+
+  defp normalize_override_unit(value) when is_atom(value), do: value
+
+  defp normalize_override_unit(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.downcase()
+    |> String.replace(~r/[\s-]+/u, "_")
+    |> safe_existing_atom_or_string()
+  end
+
+  defp normalize_override_unit(value), do: value
+
+  defp temporal_to_display(value, column, :instant, timezone) do
+    Selecto.Temporal.to_display_temporal(column || %{}, value)
+    |> maybe_shift_datetime(timezone)
+  end
+
+  defp temporal_to_display(value, column, _temporal_kind, _timezone) do
+    Selecto.Temporal.to_display_temporal(column || %{}, value)
+  end
+
+  defp maybe_shift_datetime(%DateTime{} = datetime, timezone) when is_binary(timezone) do
+    case DateTime.shift_zone(datetime, timezone) do
+      {:ok, shifted} -> shifted
+      _ -> datetime
+    end
+  end
+
+  defp maybe_shift_datetime(value, _timezone), do: value
+
+  defp timezone_label(%DateTime{} = datetime), do: datetime.time_zone || "UTC"
+
+  defp format_number(value, presentation, _context) do
+    digits =
+      presentation
+      |> Map.get(:format, %{})
+      |> Map.get(:maximum_fraction_digits, default_digits(value))
+
+    case to_float(value) do
+      nil -> value_to_string(value)
+      float when digits <= 0 -> float |> Float.round(0) |> trunc() |> Integer.to_string()
+      float -> :erlang.float_to_binary(float, decimals: digits)
+    end
+  end
+
+  defp default_digits(value) when is_integer(value), do: 0
+  defp default_digits(%D{}), do: 2
+  defp default_digits(_value), do: 2
+
+  defp convert_measurement(value, canonical_unit, target_unit)
+       when canonical_unit in [nil, target_unit] or target_unit == nil do
+    value
+  end
+
+  defp convert_measurement(value, :celsius, :fahrenheit),
+    do: numeric_transform(value, &(&1 * 9 / 5 + 32))
+
+  defp convert_measurement(value, :fahrenheit, :celsius),
+    do: numeric_transform(value, &((&1 - 32) * 5 / 9))
+
+  defp convert_measurement(value, :celsius, :kelvin), do: numeric_transform(value, &(&1 + 273.15))
+  defp convert_measurement(value, :kelvin, :celsius), do: numeric_transform(value, &(&1 - 273.15))
+
+  defp convert_measurement(value, :fahrenheit, :kelvin),
+    do: numeric_transform(value, &((&1 - 32) * 5 / 9 + 273.15))
+
+  defp convert_measurement(value, :kelvin, :fahrenheit),
+    do: numeric_transform(value, &((&1 - 273.15) * 9 / 5 + 32))
+
+  defp convert_measurement(value, source_unit, target_unit) do
+    with {:ok, source_factor} <- factor(source_unit),
+         {:ok, target_factor} <- factor(target_unit),
+         float when is_float(float) <- to_float(value) do
+      float * source_factor / target_factor
+    else
+      _ -> value
+    end
+  end
+
+  defp factor(:millimeter), do: {:ok, 0.001}
+  defp factor(:centimeter), do: {:ok, 0.01}
+  defp factor(:meter), do: {:ok, 1.0}
+  defp factor(:kilometer), do: {:ok, 1000.0}
+  defp factor(:inch), do: {:ok, 0.0254}
+  defp factor(:foot), do: {:ok, 0.3048}
+  defp factor(:yard), do: {:ok, 0.9144}
+  defp factor(:mile), do: {:ok, 1609.344}
+  defp factor(:gram), do: {:ok, 1.0}
+  defp factor(:kilogram), do: {:ok, 1000.0}
+  defp factor(:ounce), do: {:ok, 28.349523125}
+  defp factor(:pound), do: {:ok, 453.59237}
+  defp factor(:milliliter), do: {:ok, 0.001}
+  defp factor(:liter), do: {:ok, 1.0}
+  defp factor(:fluid_ounce), do: {:ok, 0.0295735295625}
+  defp factor(:gallon), do: {:ok, 3.785411784}
+  defp factor(:square_meter), do: {:ok, 1.0}
+  defp factor(:square_foot), do: {:ok, 0.09290304}
+  defp factor(:acre), do: {:ok, 4046.8564224}
+  defp factor(:hectare), do: {:ok, 10000.0}
+  defp factor(:meter_per_second), do: {:ok, 1.0}
+  defp factor(:kilometer_per_hour), do: {:ok, 0.2777777778}
+  defp factor(:mile_per_hour), do: {:ok, 0.44704}
+  defp factor(_unit), do: :error
+
+  defp numeric_transform(value, fun) do
+    case to_float(value) do
+      nil -> value
+      float -> fun.(float)
+    end
+  end
+
+  defp to_float(value) when is_float(value), do: value
+  defp to_float(value) when is_integer(value), do: value * 1.0
+  defp to_float(%D{} = value), do: D.to_float(value)
+
+  defp to_float(value) when is_binary(value) do
+    case Float.parse(String.trim(value)) do
+      {float, ""} -> float
+      _ -> nil
+    end
+  end
+
+  defp to_float(_value), do: nil
+
+  defp value_to_string(nil), do: ""
+  defp value_to_string(value) when is_binary(value), do: value
+  defp value_to_string(value) when is_atom(value), do: Atom.to_string(value)
+  defp value_to_string(value) when is_integer(value), do: Integer.to_string(value)
+
+  defp value_to_string(value) when is_float(value),
+    do: :erlang.float_to_binary(value, decimals: 2)
+
+  defp value_to_string(%Date{} = value), do: Date.to_iso8601(value)
+  defp value_to_string(%NaiveDateTime{} = value), do: Calendar.strftime(value, "%Y-%m-%d %H:%M")
+  defp value_to_string(%DateTime{} = value), do: Calendar.strftime(value, "%Y-%m-%d %H:%M")
+  defp value_to_string(%D{} = value), do: D.to_string(value, :normal)
+  defp value_to_string(value), do: inspect(value)
+
+  defp safe_existing_atom_or_string(value) do
+    try do
+      String.to_existing_atom(value)
+    rescue
+      ArgumentError -> value
+    end
+  end
+end

--- a/lib/selecto_components/presentation.ex
+++ b/lib/selecto_components/presentation.ex
@@ -53,6 +53,10 @@ defmodule SelectoComponents.Presentation do
     mile_per_hour: "mph"
   }
 
+  @comma_decimal_locales ~w(
+    bg cs da de el es et fi fr hr hu it lt lv nb nl pl pt ro sk sl sr sv tr uk
+  )
+
   @spec resolve_context(map() | nil) :: map()
   def resolve_context(context) when is_map(context) do
     %{
@@ -64,7 +68,15 @@ defmodule SelectoComponents.Presentation do
         normalize_unit_overrides(
           Map.get(context, :unit_overrides) || Map.get(context, "unit_overrides", %{})
         ),
-      conventions: Map.get(context, :conventions) || Map.get(context, "conventions") || %{}
+      conventions: Map.get(context, :conventions) || Map.get(context, "conventions") || %{},
+      locale_adapter:
+        normalize_locale_adapter(
+          Map.get(context, :locale_adapter) || Map.get(context, "locale_adapter")
+        ),
+      locale_adapter_options:
+        normalize_locale_adapter_options(
+          Map.get(context, :locale_adapter_options) || Map.get(context, "locale_adapter_options")
+        )
     }
   end
 
@@ -74,7 +86,9 @@ defmodule SelectoComponents.Presentation do
       timezone: "Etc/UTC",
       unit_system: :metric,
       unit_overrides: %{},
-      conventions: %{}
+      conventions: %{},
+      locale_adapter: nil,
+      locale_adapter_options: %{}
     }
   end
 
@@ -99,6 +113,33 @@ defmodule SelectoComponents.Presentation do
     formatted = format_value(value, column, context, opts)
     value_to_string(formatted)
   end
+
+  @spec parse_number(term(), map() | nil) :: float() | nil
+  def parse_number(value, context \\ nil)
+
+  def parse_number(value, _context) when is_integer(value), do: value * 1.0
+  def parse_number(value, _context) when is_float(value), do: value
+  def parse_number(%D{} = value, _context), do: D.to_float(value)
+
+  def parse_number(value, context) when is_binary(value) do
+    context = resolve_context(context)
+
+    case parse_number_with_adapter(value, context) do
+      {:ok, float} when is_float(float) ->
+        float
+
+      _ ->
+        with normalized when is_binary(normalized) and normalized != "" <-
+               normalize_number_string(value, context),
+             {float, ""} <- Float.parse(normalized) do
+          float
+        else
+          _ -> nil
+        end
+    end
+  end
+
+  def parse_number(_value, _context), do: nil
 
   @spec display_unit(map() | nil, map() | nil) :: atom() | String.t() | nil
   def display_unit(column, context) do
@@ -200,6 +241,12 @@ defmodule SelectoComponents.Presentation do
 
   defp normalize_locale(_locale), do: nil
 
+  defp normalize_locale_adapter(value) when is_atom(value), do: value
+  defp normalize_locale_adapter(_value), do: nil
+
+  defp normalize_locale_adapter_options(options) when is_map(options), do: options
+  defp normalize_locale_adapter_options(_options), do: %{}
+
   defp normalize_timezone(nil), do: "Etc/UTC"
 
   defp normalize_timezone(timezone) when is_binary(timezone) do
@@ -269,18 +316,142 @@ defmodule SelectoComponents.Presentation do
 
   defp timezone_label(%DateTime{} = datetime), do: datetime.time_zone || "UTC"
 
-  defp format_number(value, presentation, _context) do
+  defp format_number(value, presentation, context) do
     digits =
       presentation
       |> Map.get(:format, %{})
       |> Map.get(:maximum_fraction_digits, default_digits(value))
 
-    case to_float(value) do
-      nil -> value_to_string(value)
-      float when digits <= 0 -> float |> Float.round(0) |> trunc() |> Integer.to_string()
-      float -> :erlang.float_to_binary(float, decimals: digits)
+    case format_number_with_adapter(value, context, digits, presentation) do
+      {:ok, formatted} when is_binary(formatted) ->
+        formatted
+
+      _ ->
+        case to_float(value) do
+          nil -> value_to_string(value)
+          float when digits <= 0 -> float |> Float.round(0) |> trunc() |> Integer.to_string()
+          float -> :erlang.float_to_binary(float, decimals: digits)
+        end
     end
   end
+
+  defp parse_number_with_adapter(value, context) do
+    case Map.get(context, :locale_adapter) do
+      adapter when is_atom(adapter) ->
+        if function_exported?(adapter, :parse_number, 2) do
+          adapter.parse_number(value, context)
+        else
+          :error
+        end
+
+      _ ->
+        :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp format_number_with_adapter(value, context, digits, presentation) do
+    case Map.get(context, :locale_adapter) do
+      adapter when is_atom(adapter) ->
+        if function_exported?(adapter, :format_number, 3) do
+          adapter.format_number(value, context,
+            digits: digits,
+            presentation: presentation,
+            locale_adapter_options: Map.get(context, :locale_adapter_options, %{})
+          )
+        else
+          :error
+        end
+
+      _ ->
+        :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp normalize_number_string(value, context) when is_binary(value) do
+    trimmed =
+      value
+      |> String.trim()
+      |> String.replace(~r/[−–—]/u, "-")
+
+    if trimmed == "" do
+      nil
+    else
+      conventions = number_conventions(context)
+      decimal_separator = Map.get(conventions, :decimal_separator, ".")
+      grouping_separators = Map.get(conventions, :grouping_separators, [])
+
+      normalized =
+        trimmed
+        |> remove_grouping_separators(grouping_separators)
+        |> normalize_decimal_separator(decimal_separator)
+
+      if Regex.match?(~r/^[-+]?(?:\d+|\d*\.\d+)$/u, normalized), do: normalized, else: nil
+    end
+  end
+
+  defp number_conventions(context) do
+    conventions = Map.get(context, :conventions, %{}) || %{}
+    locale = Map.get(context, :locale)
+    decimal_separator = convention_decimal_separator(conventions, locale)
+    grouping_separators = convention_grouping_separators(conventions, decimal_separator)
+
+    %{
+      decimal_separator: decimal_separator,
+      grouping_separators: grouping_separators
+    }
+  end
+
+  defp convention_decimal_separator(conventions, locale) do
+    case Map.get(conventions, :decimal_separator) || Map.get(conventions, "decimal_separator") do
+      separator when separator in [".", ","] -> separator
+      _ -> default_decimal_separator(locale)
+    end
+  end
+
+  defp convention_grouping_separators(conventions, decimal_separator) do
+    explicit =
+      Map.get(conventions, :grouping_separators) ||
+        Map.get(conventions, "grouping_separators") ||
+        Map.get(conventions, :grouping_separator) ||
+        Map.get(conventions, "grouping_separator") ||
+        Map.get(conventions, :group_separator) ||
+        Map.get(conventions, "group_separator")
+
+    separators =
+      case explicit do
+        values when is_list(values) -> values
+        value when is_binary(value) -> [value]
+        _ -> default_grouping_separators(decimal_separator)
+      end
+
+    separators
+    |> Enum.map(&to_string/1)
+    |> Enum.reject(&(&1 in [nil, "", decimal_separator]))
+    |> Enum.uniq()
+  end
+
+  defp default_decimal_separator(locale) when is_binary(locale) do
+    locale_prefix = locale |> String.downcase() |> String.split(~r/[-_]/u, parts: 2) |> hd()
+    if locale_prefix in @comma_decimal_locales, do: ",", else: "."
+  end
+
+  defp default_decimal_separator(_locale), do: "."
+
+  defp default_grouping_separators("."), do: [",", " ", <<194, 160>>, <<226, 128, 175>>, "'", "’"]
+  defp default_grouping_separators(","), do: [".", " ", <<194, 160>>, <<226, 128, 175>>, "'", "’"]
+  defp default_grouping_separators(_), do: [",", ".", " "]
+
+  defp remove_grouping_separators(value, separators) do
+    Enum.reduce(separators, value, fn separator, acc -> String.replace(acc, separator, "") end)
+  end
+
+  defp normalize_decimal_separator(value, "."), do: value
+  defp normalize_decimal_separator(value, ","), do: String.replace(value, ",", ".")
+  defp normalize_decimal_separator(value, separator), do: String.replace(value, separator, ".")
 
   defp default_digits(value) when is_integer(value), do: 0
   defp default_digits(%D{}), do: 2
@@ -353,10 +524,7 @@ defmodule SelectoComponents.Presentation do
   defp to_float(%D{} = value), do: D.to_float(value)
 
   defp to_float(value) when is_binary(value) do
-    case Float.parse(String.trim(value)) do
-      {float, ""} -> float
-      _ -> nil
-    end
+    parse_number(value, nil)
   end
 
   defp to_float(_value), do: nil

--- a/lib/selecto_components/presentation/locale_adapter.ex
+++ b/lib/selecto_components/presentation/locale_adapter.ex
@@ -1,0 +1,6 @@
+defmodule SelectoComponents.Presentation.LocaleAdapter do
+  @moduledoc false
+
+  @callback parse_number(String.t(), map()) :: {:ok, float()} | :error
+  @callback format_number(term(), map(), keyword()) :: {:ok, String.t()} | :error
+end

--- a/lib/selecto_components/presentation/locale_adapter.ex
+++ b/lib/selecto_components/presentation/locale_adapter.ex
@@ -3,4 +3,5 @@ defmodule SelectoComponents.Presentation.LocaleAdapter do
 
   @callback parse_number(String.t(), map()) :: {:ok, float()} | :error
   @callback format_number(term(), map(), keyword()) :: {:ok, String.t()} | :error
+  @callback format_temporal(term(), map(), keyword()) :: {:ok, String.t()} | :error
 end

--- a/lib/selecto_components/results.ex
+++ b/lib/selecto_components/results.ex
@@ -17,6 +17,7 @@ defmodule SelectoComponents.Results do
         applied_view: Map.get(assigns, :applied_view),
         executed: Map.get(assigns, :executed, false),
         query_results: Map.get(assigns, :query_results),
+        presentation_context: Map.get(assigns, :presentation_context, %{}),
         theme: Theme.resolve_theme(assigns),
         theme_stylesheet: Map.get(assigns, :theme_stylesheet, Theme.stylesheet())
       )
@@ -117,6 +118,7 @@ defmodule SelectoComponents.Results do
           theme={@theme}
           selecto={@selecto}
           query_results={@query_results}
+          presentation_context={@presentation_context}
           view_meta={@view_meta}
           view_opts={@view_opts}
           enable_modal_detail={Map.get(assigns, :enable_modal_detail, false)}

--- a/lib/selecto_components/scheduled_exports/service.ex
+++ b/lib/selecto_components/scheduled_exports/service.ex
@@ -129,6 +129,9 @@ defmodule SelectoComponents.ScheduledExports.Service do
            Exporter.build(format, query_results,
              view_mode: Keyword.get(opts, :view_mode, "results"),
              view_config: Keyword.get(opts, :view_config),
+             selecto: Keyword.get(opts, :selecto),
+             presentation_context: Keyword.get(opts, :presentation_context, %{}),
+             export_mode: Keyword.get(opts, :export_mode, :raw),
              exported_at: exported_at
            ),
          :ok <-

--- a/lib/selecto_components/views/aggregate/component.ex
+++ b/lib/selecto_components/views/aggregate/component.ex
@@ -4,6 +4,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   """
   use Phoenix.LiveComponent
   alias SelectoComponents.Env
+  alias SelectoComponents.Presentation
   alias SelectoComponents.QueryResults
   alias SelectoComponents.Theme
   alias SelectoComponents.Views.Aggregate.Options
@@ -47,6 +48,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         aggregate_server_paged?: incoming_server_paged?,
         aggregate_page_loading?: false,
         aggregate_requested_page: nil,
+        presentation_context: Map.get(assigns, :presentation_context, %{}),
         theme:
           Map.get(assigns, :theme, Map.get(socket.assigns, :theme, Theme.default_theme(:light))),
         last_update: System.system_time(:microsecond)
@@ -160,7 +162,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   # Format a value for display
   # With COALESCE, "[NULL]" strings are already in the data and should be displayed as-is
   # ROLLUP NULLs (nil/empty) should also be shown as "[NULL]"
-  defp format_value(value) do
+  defp format_value(value, column_def \\ nil, presentation_context \\ %{}) do
     case value do
       nil ->
         "[NULL]"
@@ -170,26 +172,38 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         "[NULL]"
 
       {coefficient, scale} when is_integer(coefficient) and is_integer(scale) and scale >= 0 ->
-        format_decimal_tuple(coefficient, scale)
+        safe_cell_value(
+          format_decimal_tuple(coefficient, scale),
+          column_def,
+          presentation_context
+        )
 
       {display_value, _id} when is_nil(display_value) or display_value == "" ->
         "[NULL]"
 
       {display_value, _id} ->
-        safe_cell_value(display_value)
+        safe_cell_value(display_value, column_def, presentation_context)
 
       tuple when is_tuple(tuple) ->
         elem_val = elem(tuple, 0)
-        if is_nil(elem_val) or elem_val == "", do: "[NULL]", else: safe_cell_value(elem_val)
+
+        if is_nil(elem_val) or elem_val == "" do
+          "[NULL]"
+        else
+          safe_cell_value(elem_val, column_def, presentation_context)
+        end
 
       # Includes "[NULL]" strings from COALESCE
       _ ->
-        safe_cell_value(value)
+        safe_cell_value(value, column_def, presentation_context)
     end
   end
 
-  defp safe_cell_value(value) do
+  defp safe_cell_value(value, column_def, presentation_context) do
     case value do
+      {:safe, _} = safe_value ->
+        safe_value
+
       nil ->
         ""
 
@@ -197,33 +211,28 @@ defmodule SelectoComponents.Views.Aggregate.Component do
       when is_integer(coefficient) and is_integer(scale) and scale >= 0 ->
         format_decimal_tuple(coefficient, scale)
 
-      value when is_tuple(value) ->
-        inspect(value)
-
       value when is_atom(value) ->
         Atom.to_string(value)
 
-      value when is_binary(value) ->
-        QueryResults.normalize_value(value)
+      value when is_tuple(value) ->
+        inspect(value)
 
       _ ->
-        if Phoenix.HTML.Safe.impl_for(value) do
-          value
-        else
-          inspect(value)
-        end
+        value
+        |> Presentation.format_cell(maybe_normalized_column(column_def), presentation_context)
+        |> QueryResults.normalize_value()
     end
   end
 
   # Format an aggregate value, applying format function if present
-  defp format_aggregate_value(value, coldef) do
+  defp format_aggregate_value(value, coldef, presentation_context) do
     formatted =
       case coldef do
         %{format: fmt_fun} when is_function(fmt_fun) -> fmt_fun.(value)
         _ -> value
       end
 
-    format_value(formatted)
+    format_value(formatted, coldef, presentation_context)
   end
 
   defp format_decimal_tuple(coefficient, 0), do: Integer.to_string(coefficient)
@@ -467,7 +476,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
               <%= if display_group_block?(block, @active_group_range) do %>
                 <%= if @continued? do %>
                   <span style="color: var(--sc-accent);">
-                    {group_block_value(block)} (continued)
+                    {group_block_value(block, @presentation_context)} (continued)
                   </span>
                 <% else %>
                   <div
@@ -475,7 +484,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
                     {@filter_attrs}
                     class="cursor-pointer hover:underline"
                   >
-                    {group_block_value(block)}
+                    {group_block_value(block, @presentation_context)}
                   </div>
                 <% end %>
               <% end %>
@@ -490,7 +499,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
           <%= if @continued? do %>
             <span style="color: var(--sc-accent);">-</span>
           <% else %>
-            {format_aggregate_value(value, coldef)}
+            {format_aggregate_value(value, coldef, @presentation_context)}
           <% end %>
         </td>
       <% end %>
@@ -764,11 +773,14 @@ defmodule SelectoComponents.Views.Aggregate.Component do
           case field do
             {:field, {:to_char, {field_name, _format}}, _alias} ->
               # Handle formatted date fields
-              Selecto.field(assigns.selecto, field_name) || %{name: display_alias, format: nil}
+              configured_column(assigns.selecto, field_name) ||
+                Selecto.field(assigns.selecto, field_name) || %{name: display_alias, format: nil}
 
             {:field, field_id, _alias} when is_binary(field_id) or is_atom(field_id) ->
               # Selecto.field now returns full custom column definitions with group_by_filter
-              result = Selecto.field(assigns.selecto, field_id)
+              result =
+                configured_column(assigns.selecto, field_id) ||
+                  Selecto.field(assigns.selecto, field_id)
 
               if result == nil do
                 # Field not found - use basic definition
@@ -779,7 +791,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
             {:field, {_extract_type, field_id, _format}, _alias} ->
               # Handle extracted fields (e.g., date parts)
-              Selecto.field(assigns.selecto, field_id) || %{name: display_alias}
+              configured_column(assigns.selecto, field_id) ||
+                Selecto.field(assigns.selecto, field_id) || %{name: display_alias}
 
             {:row, [display_field | _rest], _alias} ->
               # For row selectors (e.g., join mode columns), look up the actual column definition
@@ -818,7 +831,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
                     nil
                   end
                 else
-                  Selecto.field(assigns.selecto, field_name)
+                  configured_column(assigns.selecto, field_name) ||
+                    Selecto.field(assigns.selecto, field_name)
                 end
 
               if result == nil do
@@ -847,10 +861,20 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         coldef =
           case agg do
             {:field, {_func, field_id}, _alias} when is_atom(field_id) ->
-              Selecto.field(assigns.selecto, field_id)
+              configured_column(assigns.selecto, field_id) ||
+                Selecto.field(assigns.selecto, field_id)
 
             {:field, field_id, _alias} when is_atom(field_id) ->
-              Selecto.field(assigns.selecto, field_id)
+              configured_column(assigns.selecto, field_id) ||
+                Selecto.field(assigns.selecto, field_id)
+
+            {:field, {_func, field_id}, _alias} when is_binary(field_id) ->
+              configured_column(assigns.selecto, field_id) ||
+                Selecto.field(assigns.selecto, field_id)
+
+            {:field, field_id, _alias} when is_binary(field_id) ->
+              configured_column(assigns.selecto, field_id) ||
+                Selecto.field(assigns.selecto, field_id)
 
             _ ->
               # Fallback to empty map for unknown aggregate types
@@ -990,7 +1014,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
             rollup_rows,
             num_group_by,
             group_by,
-            display_group_axes,
+            aggregates_processed,
             grid_colorize,
             grid_color_scale,
             assigns.theme
@@ -999,6 +1023,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
     assigns =
       assign(assigns,
+        presentation_context: Map.get(assigns, :presentation_context, %{}),
         rollup_rows: rollup_rows,
         paged_rollup_rows: paged_rollup_rows,
         num_group_by: num_group_by,
@@ -1213,8 +1238,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
                 </th>
                 <%= for col_value <- @grid_data.col_headers do %>
                   <th class="sticky top-0 z-20 px-3 py-3.5 text-left text-sm font-semibold" style="background: var(--sc-surface-bg-alt); color: var(--sc-text-primary);">
-                    <span class={null_grid_text_class(format_grid_axis_value(col_value, @grid_data.col_axis))}>
-                      {format_grid_axis_value(col_value, @grid_data.col_axis)}
+                    <span class={null_grid_text_class(format_group_value(col_value, @grid_data.col_coldef, @presentation_context))}>
+                      {format_group_value(col_value, @grid_data.col_coldef, @presentation_context)}
                     </span>
                   </th>
                 <% end %>
@@ -1223,8 +1248,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
             <tbody style="background: var(--sc-surface-bg); border-color: var(--sc-surface-border);">
               <tr :for={row_value <- @grid_data.row_headers}>
                 <td class="sticky left-0 z-10 px-3 py-2 text-sm font-semibold" style="background: var(--sc-surface-bg); color: var(--sc-text-primary); box-shadow: 1px 0 0 0 var(--sc-surface-border);">
-                  <span class={null_grid_text_class(format_grid_axis_value(row_value, @grid_data.row_axis))}>
-                    {format_grid_axis_value(row_value, @grid_data.row_axis)}
+                  <span class={null_grid_text_class(format_group_value(row_value, @grid_data.row_coldef, @presentation_context))}>
+                    {format_group_value(row_value, @grid_data.row_coldef, @presentation_context)}
                   </span>
                 </td>
           <td
@@ -1241,8 +1266,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
                     )}
                     class="cursor-pointer whitespace-nowrap hover:underline"
                   >
-                    <span class={null_grid_text_class(format_value(Map.get(@grid_data.cells, {row_value, col_value})))}>
-                      {format_value(Map.get(@grid_data.cells, {row_value, col_value}))}
+                    <span class={null_grid_text_class(format_aggregate_value(Map.get(@grid_data.cells, {row_value, col_value}), @grid_data.agg_coldef, @presentation_context))}>
+                      {format_aggregate_value(Map.get(@grid_data.cells, {row_value, col_value}), @grid_data.agg_coldef, @presentation_context)}
                     </span>
                   </div>
                 </td>
@@ -1283,6 +1308,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
                 num_group_by={@num_group_by}
                 group_by={@group_by}
                 aggregate={@aggregate}
+                presentation_context={@presentation_context}
                 theme={@theme}
               />
             </tbody>
@@ -1299,8 +1325,8 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   defp build_grid_data(
          paged_rollup_rows,
          num_group_by,
-         _group_by,
-         display_group_axes,
+         group_by,
+         aggregates,
          colorize?,
          scale_mode,
          theme
@@ -1326,6 +1352,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
       end)
       |> Enum.reverse()
 
+    display_group_axes = visible_group_axes(group_by)
     row_axis = Enum.at(display_group_axes, 0, default_grid_axis("Group 1"))
     col_axis = Enum.at(display_group_axes, 1, default_grid_axis("Group 2"))
 
@@ -1346,8 +1373,12 @@ defmodule SelectoComponents.Views.Aggregate.Component do
         {row_acc, col_acc, cells_acc, group_cols_acc}
       end)
 
-    row_headers = sort_grid_axis_values(row_headers, row_axis)
-    col_headers = sort_grid_axis_values(col_headers, col_axis)
+    row_coldef = grid_axis_coldef(row_axis)
+    col_coldef = grid_axis_coldef(col_axis)
+    agg_coldef = grid_coldef(aggregates, 0)
+
+    row_headers = sort_group_values(row_headers, row_coldef)
+    col_headers = sort_group_values(col_headers, col_coldef)
     cell_styles = build_grid_cell_styles(cells, colorize?, scale_mode, theme)
 
     %{
@@ -1357,8 +1388,9 @@ defmodule SelectoComponents.Views.Aggregate.Component do
       cells: cells,
       cell_group_cols: cell_group_cols,
       cell_styles: cell_styles,
-      row_axis: row_axis,
-      col_axis: col_axis
+      row_coldef: row_coldef,
+      col_coldef: col_coldef,
+      agg_coldef: agg_coldef
     }
   end
 
@@ -1452,48 +1484,73 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
   defp selected_field_alias(_selected_field, fallback), do: fallback
 
+  defp grid_coldef(group_by, idx) do
+    case Enum.at(group_by, idx) do
+      {_alias, {:group_by, _field, coldef}} -> coldef
+      {_alias, {:agg, _field, coldef}} -> coldef
+      _ -> %{}
+    end
+  end
+
+  defp grid_axis_coldef(%{defs: [{_alias, {:group_by, _field, coldef}}]}), do: coldef
+
+  defp grid_axis_coldef(%{defs: defs}) when is_list(defs) do
+    %{
+      linked_defs: Enum.map(defs, fn {_alias, {:group_by, _field, coldef}} -> coldef end)
+    }
+  end
+
+  defp grid_axis_coldef(_axis), do: %{}
+
   defp default_grid_axis(alias_name) do
-    %{alias: alias_name, defs: [], start_idx: 0, end_idx: 0}
+    %{
+      alias: alias_name,
+      defs: [],
+      start_idx: nil,
+      end_idx: nil
+    }
   end
-
-  defp format_grid_axis_value(value, %{defs: defs}) when is_list(defs) and defs != [] do
-    defs
-    |> Enum.zip(List.wrap(value))
-    |> Enum.map(fn {{_alias, {:group_by, _field, coldef}}, axis_value} ->
-      format_group_value(axis_value, coldef)
-    end)
-    |> Enum.join(" / ")
-  end
-
-  defp format_grid_axis_value(value, _axis), do: format_value(value)
 
   defp grid_axis_value(row, %{start_idx: start_idx, end_idx: end_idx})
        when is_list(row) and is_integer(start_idx) and is_integer(end_idx) do
-    Enum.slice(row, start_idx, end_idx - start_idx + 1)
-  end
+    values = Enum.slice(row, start_idx, end_idx - start_idx + 1)
 
-  defp grid_axis_value(_row, _axis), do: []
-
-  defp sort_grid_axis_values(values, %{defs: [{_alias, {:group_by, _field, coldef}}]}) do
-    values
-    |> Enum.map(fn
-      [value] -> value
-      value -> value
-    end)
-    |> sort_group_values(coldef)
-    |> Enum.map(&List.wrap/1)
-  end
-
-  defp sort_grid_axis_values(values, _axis), do: values
-
-  defp format_group_value(value, coldef) do
-    display_value = display_value_for_group(value, coldef)
-
-    case Map.get(coldef || %{}, :group_format) || Map.get(coldef || %{}, "group_format") do
-      "D" -> weekday_name(display_value)
-      _ -> format_value(display_value)
+    case values do
+      [single] -> single
+      many -> many
     end
   end
+
+  defp grid_axis_value(_row, _axis), do: nil
+
+  defp format_group_value(value, coldef, presentation_context) do
+    if linked_grid_axis?(coldef) and is_list(value) do
+      value
+      |> Enum.zip(Map.get(coldef, :linked_defs, []))
+      |> Enum.map(fn {part_value, part_coldef} ->
+        format_group_value(part_value, part_coldef, presentation_context)
+      end)
+      |> Enum.join(" / ")
+    else
+      display_value = display_value_for_group(value, coldef)
+
+      case Map.get(coldef || %{}, :group_format) || Map.get(coldef || %{}, "group_format") do
+        "D" ->
+          weekday_name(display_value)
+
+        format when is_binary(format) and format != "" ->
+          format_value(display_value, nil, presentation_context)
+
+        _ ->
+          format_value(display_value, coldef, presentation_context)
+      end
+    end
+  end
+
+  defp linked_grid_axis?(coldef) when is_map(coldef),
+    do: is_list(Map.get(coldef, :linked_defs)) and Map.get(coldef, :linked_defs) != []
+
+  defp linked_grid_axis?(_coldef), do: false
 
   defp display_value_for_group(value, coldef) do
     if composite_group_value?(coldef) do
@@ -1563,6 +1620,38 @@ defmodule SelectoComponents.Views.Aggregate.Component do
   end
 
   defp parse_int(_), do: nil
+
+  defp configured_column(_selecto, nil), do: nil
+
+  defp configured_column(selecto, key) do
+    columns = Selecto.columns(selecto)
+
+    Map.get(columns, key) ||
+      case key do
+        value when is_atom(value) ->
+          Map.get(columns, Atom.to_string(value))
+
+        value when is_binary(value) ->
+          case safe_existing_atom(value) do
+            nil -> nil
+            atom_key -> Map.get(columns, atom_key)
+          end
+
+        _ ->
+          nil
+      end
+  end
+
+  defp safe_existing_atom(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp safe_existing_atom(_value), do: nil
+
+  defp maybe_normalized_column(nil), do: nil
+  defp maybe_normalized_column(column_def), do: Selecto.Presentation.normalize_column(column_def)
 
   defp sort_group_values(values, coldef) when is_list(values) do
     format = Map.get(coldef || %{}, :group_format) || Map.get(coldef || %{}, "group_format")
@@ -1709,20 +1798,22 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
   defp row_group_blocks(_group_by, _group_cols), do: []
 
-  defp group_block_value(%{defs: defs, values: values}) do
+  defp group_block_value(block, presentation_context \\ %{})
+
+  defp group_block_value(%{defs: defs, values: values}, presentation_context) do
     formatted_values =
       values
       |> Enum.zip(defs)
       |> Enum.take_while(fn {value, _definition} -> value not in [nil, ""] end)
       |> Enum.map(fn {value, {_alias, {:group_by, _field, coldef}}} ->
-        format_group_value(value, coldef)
+        format_group_value(value, coldef, presentation_context)
       end)
 
     case formatted_values do
       [] ->
         case Enum.zip(values, defs) do
           [{value, {_alias, {:group_by, _field, coldef}}} | _rest] ->
-            format_group_value(value, coldef)
+            format_group_value(value, coldef, presentation_context)
 
           _ ->
             ""
@@ -1733,7 +1824,7 @@ defmodule SelectoComponents.Views.Aggregate.Component do
     end
   end
 
-  defp group_block_value(_block), do: ""
+  defp group_block_value(_block, _presentation_context), do: ""
 
   defp display_group_block?(_block, nil), do: false
 

--- a/lib/selecto_components/views/aggregate/component.ex
+++ b/lib/selecto_components/views/aggregate/component.ex
@@ -1798,8 +1798,6 @@ defmodule SelectoComponents.Views.Aggregate.Component do
 
   defp row_group_blocks(_group_by, _group_cols), do: []
 
-  defp group_block_value(block, presentation_context \\ %{})
-
   defp group_block_value(%{defs: defs, values: values}, presentation_context) do
     formatted_values =
       values

--- a/lib/selecto_components/views/aggregate/process.ex
+++ b/lib/selecto_components/views/aggregate/process.ex
@@ -33,6 +33,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
   def view(_opt, params, columns, filtered, selecto) do
     group_by_params = Map.get(params, "group_by", %{})
+    presentation_context = runtime_presentation_context(params)
     per_page = Options.normalize_per_page_param(Map.get(params, "aggregate_per_page"))
     grid = truthy_param?(Map.get(params, "aggregate_grid"))
     grid_colorize = truthy_param?(Map.get(params, "aggregate_grid_colorize"))
@@ -44,7 +45,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
       Map.get(params, "aggregate", %{})
       |> aggregates(columns)
 
-    group_by = group_by_params |> group_by(columns, selecto)
+    group_by = group_by_params |> group_by(columns, selecto, presentation_context)
 
     # Wrap only text-compatible group-by selectors in COALESCE to display '[NULL]'.
     # Applying string fallback to non-text fields (integer, enum, array, etc.) causes SQL type errors.
@@ -138,7 +139,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
   defp linked_to_next?(_col), do: false
 
-  def group_by(group_by, columns, selecto) do
+  def group_by(group_by, columns, selecto, presentation_context \\ %{}) do
     group_by
     |> Map.values()
     |> Enum.sort(fn a, b ->
@@ -218,7 +219,7 @@ defmodule SelectoComponents.Views.Aggregate.Process do
         else
           case Selecto.Temporal.date_like_type(col) || col.type do
             x when x in [:naive_datetime, :utc_datetime, :date] ->
-              {:field, datetime_gb_proc(col, e), alias}
+              {:field, datetime_gb_proc(col, e, presentation_context), alias}
 
             x when x in [:integer, :float, :decimal, :id] ->
               # Check if buckets format is specified
@@ -481,23 +482,20 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
   defp to_existing_atom_safe(_), do: :error
 
-  defp datetime_gb_proc(col, config) do
+  defp datetime_gb_proc(col, config, presentation_context) do
     format = Map.get(config, "format")
     bucket_ranges = Map.get(config, "bucket_ranges")
+    field_with_alias = aggregate_field_ref(col.colid)
 
     case format do
       # Standard date formats
       x when x in ~w(YYYY-MM-DD YYYY-MM YYYY YYYY-WW YYYY-Q MM DD D HH24) ->
-        {:to_char, {col.colid, x}}
+        maybe_timezone_aware_datetime_selector(col, field_with_alias, x, presentation_context)
 
       # Bucket formats
       "age_buckets" when is_binary(bucket_ranges) and bucket_ranges != "" ->
         # Generate CASE expression for age buckets in group by.
         # Joined fields need their fully-qualified reference, not the pivot alias.
-        field_with_alias = aggregate_field_ref(col.colid)
-
-        alias SelectoComponents.Helpers.BucketParser
-
         case_sql =
           BucketParser.generate_bucket_case_sql(
             "(CURRENT_DATE - DATE(#{field_with_alias}))",
@@ -508,10 +506,6 @@ defmodule SelectoComponents.Views.Aggregate.Process do
         {:raw_sql, case_sql}
 
       "custom_buckets" when is_binary(bucket_ranges) and bucket_ranges != "" ->
-        field_with_alias = aggregate_field_ref(col.colid)
-
-        alias SelectoComponents.Helpers.BucketParser
-
         case_sql =
           BucketParser.generate_bucket_case_sql(
             field_with_alias,
@@ -522,13 +516,9 @@ defmodule SelectoComponents.Views.Aggregate.Process do
         {:raw_sql, case_sql}
 
       "year_buckets" when is_binary(bucket_ranges) and bucket_ranges != "" ->
-        field_with_alias = aggregate_field_ref(col.colid)
-
-        alias SelectoComponents.Helpers.BucketParser
-
         case_sql =
           BucketParser.generate_bucket_case_sql(
-            "EXTRACT(YEAR FROM #{field_with_alias})",
+            year_bucket_extract_sql(col, field_with_alias, presentation_context),
             bucket_ranges,
             :integer
           )
@@ -537,7 +527,12 @@ defmodule SelectoComponents.Views.Aggregate.Process do
 
       _ ->
         # Default to day format
-        {:to_char, {col.colid, "YYYY-MM-DD"}}
+        maybe_timezone_aware_datetime_selector(
+          col,
+          field_with_alias,
+          "YYYY-MM-DD",
+          presentation_context
+        )
     end
   end
 
@@ -545,6 +540,57 @@ defmodule SelectoComponents.Views.Aggregate.Process do
     colid_str = to_string(colid)
     if String.contains?(colid_str, "."), do: colid_str, else: "selecto_root." <> colid_str
   end
+
+  defp runtime_presentation_context(params) when is_map(params) do
+    Map.get(params, "_presentation_context", %{})
+  end
+
+  defp runtime_presentation_context(_params), do: %{}
+
+  defp maybe_timezone_aware_datetime_selector(col, field_ref, format, presentation_context) do
+    if timezone_grouping_applicable?(col, presentation_context) do
+      {:raw_sql, timezone_aware_to_char_sql(col, field_ref, format, presentation_context)}
+    else
+      {:to_char, {col.colid, format}}
+    end
+  end
+
+  defp year_bucket_extract_sql(col, field_ref, presentation_context) do
+    if timezone_grouping_applicable?(col, presentation_context) do
+      "EXTRACT(YEAR FROM #{timezone_grouping_expression(col, field_ref, presentation_context)})"
+    else
+      "EXTRACT(YEAR FROM #{field_ref})"
+    end
+  end
+
+  defp timezone_grouping_applicable?(col, presentation_context) do
+    Selecto.Presentation.temporal_kind(col) == :instant and
+      is_binary(runtime_timezone(presentation_context)) and
+      runtime_timezone(presentation_context) != ""
+  end
+
+  defp timezone_aware_to_char_sql(col, field_ref, format, presentation_context) do
+    "to_char(#{timezone_grouping_expression(col, field_ref, presentation_context)}, '#{format}')"
+  end
+
+  defp timezone_grouping_expression(col, field_ref, presentation_context) do
+    timezone = runtime_timezone(presentation_context)
+
+    case Selecto.Temporal.epoch_storage(col) do
+      :unix_seconds -> "to_timestamp(#{field_ref}) AT TIME ZONE '#{timezone}'"
+      :unix_milliseconds -> "to_timestamp((#{field_ref}) / 1000.0) AT TIME ZONE '#{timezone}'"
+      _ -> "#{field_ref} AT TIME ZONE '#{timezone}'"
+    end
+  end
+
+  defp runtime_timezone(presentation_context) when is_map(presentation_context) do
+    case Map.get(presentation_context, :timezone, Map.get(presentation_context, "timezone")) do
+      timezone when is_binary(timezone) and timezone != "" -> timezone
+      _ -> nil
+    end
+  end
+
+  defp runtime_timezone(_presentation_context), do: nil
 
   def aggregates(aggregates, columns) do
     result =

--- a/lib/selecto_components/views/detail/component.ex
+++ b/lib/selecto_components/views/detail/component.ex
@@ -7,7 +7,7 @@ defmodule SelectoComponents.Views.Detail.Component do
   alias SelectoComponents.Env
   alias SelectoComponents.ErrorHandling.ErrorBuilder
   alias SelectoComponents.EnhancedTable.Sorting
-  alias SelectoComponents.QueryResults
+  alias SelectoComponents.Presentation
   alias SelectoComponents.Theme
   alias SelectoComponents.Views.Detail.RowActions
   use Phoenix.LiveComponent
@@ -46,6 +46,7 @@ defmodule SelectoComponents.Views.Detail.Component do
       socket
       |> assign(assigns)
       |> assign(:theme, Map.get(assigns, :theme, Theme.default_theme(:light)))
+      |> assign(:presentation_context, Map.get(assigns, :presentation_context, %{}))
       |> assign(:columns_config, init_columns_config(columns))
 
     {:ok, socket}
@@ -454,7 +455,7 @@ defmodule SelectoComponents.Views.Detail.Component do
                           map_get_flexible(resrow, column_alias) ||
                           Enum.at(resrow_list, column_idx)
                     end %>
-                  <% def = Selecto.columns(@selecto)[column_field] %>
+                  <% def = resolve_column_definition(@selecto, column_field, column_alias) %>
                   <%= case def do %>
                     <% %{format: :component} = def -> %>
                       {safe_render_component(def.component, %{
@@ -464,7 +465,7 @@ defmodule SelectoComponents.Views.Detail.Component do
                     <% %{format: :link} = def -> %>
                       {safe_render_link(def.link_parts, row_value)}
                     <% _ -> %>
-                      {safe_cell_value(row_value)}
+                      {safe_cell_value(row_value, def, @presentation_context)}
                   <% end %>
                 </td>
 
@@ -1039,7 +1040,7 @@ defmodule SelectoComponents.Views.Detail.Component do
 
   defp config_get(_config, _key), do: nil
 
-  defp safe_cell_value(value) do
+  defp safe_cell_value(value, column_def \\ nil, presentation_context \\ %{}) do
     case value do
       {:safe, _} = safe_value ->
         safe_value
@@ -1047,19 +1048,58 @@ defmodule SelectoComponents.Views.Detail.Component do
       value when is_tuple(value) ->
         inspect(value)
 
+      nil ->
+        ""
+
+      value when is_atom(value) ->
+        Atom.to_string(value)
+
       _ ->
-        if Phoenix.HTML.Safe.impl_for(value) do
-          value
-        else
-          case value do
-            nil -> ""
-            value when is_atom(value) -> Atom.to_string(value)
-            value when is_binary(value) -> QueryResults.normalize_value(value)
-            _ -> inspect(value)
-          end
-        end
+        Presentation.format_cell(
+          value,
+          maybe_normalized_column(column_def),
+          presentation_context
+        )
     end
   end
+
+  defp resolve_column_definition(nil, _field, _alias), do: nil
+
+  defp resolve_column_definition(selecto, field, alias_name) do
+    configured_column(selecto, field) ||
+      configured_column(selecto, alias_name) ||
+      Selecto.field(selecto, field) ||
+      if(alias_name, do: Selecto.field(selecto, alias_name), else: nil)
+  end
+
+  defp configured_column(_selecto, nil), do: nil
+
+  defp configured_column(selecto, key) do
+    columns = Selecto.columns(selecto)
+
+    Map.get(columns, key) ||
+      case key do
+        value when is_binary(value) ->
+          case safe_existing_atom(value) do
+            nil -> nil
+            atom_key -> Map.get(columns, atom_key)
+          end
+
+        _ ->
+          nil
+      end
+  end
+
+  defp safe_existing_atom(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp safe_existing_atom(_value), do: nil
+
+  defp maybe_normalized_column(nil), do: nil
+  defp maybe_normalized_column(column_def), do: Selecto.Presentation.normalize_column(column_def)
 
   defp safe_render_component(component_fn, params) do
     try do

--- a/lib/selecto_components/views/graph/component.ex
+++ b/lib/selecto_components/views/graph/component.ex
@@ -6,6 +6,7 @@ defmodule SelectoComponents.Views.Graph.Component do
   require Logger
   alias SelectoComponents.Env
   alias SelectoComponents.ErrorHandling.ErrorBuilder
+  alias SelectoComponents.Presentation
   alias SelectoComponents.QueryResults
   alias SelectoComponents.Theme
 
@@ -208,7 +209,7 @@ defmodule SelectoComponents.Views.Graph.Component do
                       const index = element.index;
                       const dataset = chartData.datasets[datasetIndex];
                       const value = dataset.data[index];
-                      const label = chartData.labels[index];
+                      const rawLabel = (chartData.rawLabels || [])[index] ?? chartData.labels[index];
                       const drillSpecs = Array.isArray(dataset.drillDown) ? dataset.drillDown[index] : [];
 
                       const indexedPayload = Array.isArray(drillSpecs)
@@ -232,7 +233,7 @@ defmodule SelectoComponents.Views.Graph.Component do
                       const yFieldName = dataset.label;
 
                       pushEvent('chart_click', {
-                        label: label,
+                        label: rawLabel,
                         value: value,
                         dataset_label: dataset.label,
                         x_field: xFieldName,
@@ -290,25 +291,64 @@ defmodule SelectoComponents.Views.Graph.Component do
     y_axis_aggregates = selecto_set[:aggregates] || []
     metric_defs = build_metric_defs(selecto_set[:graph_series_defs], y_axis_aggregates)
     series_groups = selecto_set[:series_groups] || []
+    presentation_context = Map.get(assigns, :presentation_context, %{})
 
     case chart_type do
       type when type in ["pie", "doughnut"] ->
-        prepare_pie_data(results, aliases, x_axis_groups, metric_defs)
+        prepare_pie_data(results, aliases, x_axis_groups, metric_defs, presentation_context)
 
       type when type in ["line", "area"] ->
-        prepare_line_data(results, aliases, x_axis_groups, metric_defs, series_groups, chart_type)
+        prepare_line_data(
+          results,
+          aliases,
+          x_axis_groups,
+          metric_defs,
+          series_groups,
+          chart_type,
+          presentation_context
+        )
 
       "scatter" ->
-        prepare_scatter_data(results, aliases, x_axis_groups, metric_defs, series_groups)
+        prepare_scatter_data(
+          results,
+          aliases,
+          x_axis_groups,
+          metric_defs,
+          series_groups,
+          presentation_context
+        )
 
       # Default to bar chart
       _ ->
-        prepare_bar_data(results, aliases, x_axis_groups, metric_defs, series_groups, chart_type)
+        prepare_bar_data(
+          results,
+          aliases,
+          x_axis_groups,
+          metric_defs,
+          series_groups,
+          chart_type,
+          presentation_context
+        )
     end
   end
 
-  defp prepare_bar_data(results, _aliases, x_axis_groups, metric_defs, series_groups, chart_type) do
-    prepare_cartesian_data(results, x_axis_groups, metric_defs, series_groups, chart_type)
+  defp prepare_bar_data(
+         results,
+         _aliases,
+         x_axis_groups,
+         metric_defs,
+         series_groups,
+         chart_type,
+         presentation_context
+       ) do
+    prepare_cartesian_data(
+      results,
+      x_axis_groups,
+      metric_defs,
+      series_groups,
+      chart_type,
+      presentation_context
+    )
   end
 
   defp prepare_line_data(
@@ -317,9 +357,17 @@ defmodule SelectoComponents.Views.Graph.Component do
          x_axis_groups,
          metric_defs,
          series_groups,
-         chart_type
+         chart_type,
+         presentation_context
        ) do
-    prepare_cartesian_data(results, x_axis_groups, metric_defs, series_groups, chart_type)
+    prepare_cartesian_data(
+      results,
+      x_axis_groups,
+      metric_defs,
+      series_groups,
+      chart_type,
+      presentation_context
+    )
   end
 
   defp filter_rollup_rows(results, num_x_fields, num_series_fields) do
@@ -331,28 +379,29 @@ defmodule SelectoComponents.Views.Graph.Component do
     end)
   end
 
-  defp prepare_pie_data(results, _aliases, x_axis_groups, _metric_defs) do
+  defp prepare_pie_data(results, _aliases, x_axis_groups, _metric_defs, presentation_context) do
     num_x_fields = max(Enum.count(x_axis_groups), 1)
     x_defs = build_group_defs(x_axis_groups, 0)
 
-    labels =
+    label_pairs =
       Enum.map(results, fn row ->
-        row
-        |> Enum.take(num_x_fields)
-        |> axis_label(x_defs)
+        values = Enum.take(row, num_x_fields)
+
+        %{
+          label: axis_label(values, x_defs, presentation_context),
+          raw_label: raw_axis_label(values, x_defs),
+          drill_down: drill_down_specs(values, x_defs)
+        }
       end)
 
+    labels = Enum.map(label_pairs, & &1.label)
+    raw_labels = Enum.map(label_pairs, & &1.raw_label)
     data = Enum.map(results, fn row -> format_numeric_value(Enum.at(row, num_x_fields)) end)
-
-    drill_down =
-      Enum.map(results, fn row ->
-        row
-        |> Enum.take(num_x_fields)
-        |> drill_down_specs(x_defs)
-      end)
+    drill_down = Enum.map(label_pairs, & &1.drill_down)
 
     %{
       labels: labels,
+      rawLabels: raw_labels,
       datasets: [
         %{
           data: data,
@@ -367,7 +416,14 @@ defmodule SelectoComponents.Views.Graph.Component do
     }
   end
 
-  defp prepare_cartesian_data(results, x_axis_groups, metric_defs, series_groups, chart_type) do
+  defp prepare_cartesian_data(
+         results,
+         x_axis_groups,
+         metric_defs,
+         series_groups,
+         chart_type,
+         presentation_context
+       ) do
     num_x_fields = max(Enum.count(x_axis_groups), 1)
     num_series_fields = Enum.count(series_groups)
     x_defs = build_group_defs(x_axis_groups, 0)
@@ -382,19 +438,20 @@ defmodule SelectoComponents.Views.Graph.Component do
       end
 
     if num_series_fields == 0 do
-      labels =
+      label_pairs =
         Enum.map(filtered_results, fn row ->
-          row
-          |> Enum.take(num_x_fields)
-          |> axis_label(x_defs)
+          values = Enum.take(row, num_x_fields)
+
+          %{
+            label: axis_label(values, x_defs, presentation_context),
+            raw_label: raw_axis_label(values, x_defs),
+            drill_down: drill_down_specs(values, x_defs)
+          }
         end)
 
-      drill_down =
-        Enum.map(filtered_results, fn row ->
-          row
-          |> Enum.take(num_x_fields)
-          |> drill_down_specs(x_defs)
-        end)
+      labels = Enum.map(label_pairs, & &1.label)
+      raw_labels = Enum.map(label_pairs, & &1.raw_label)
+      drill_down = Enum.map(label_pairs, & &1.drill_down)
 
       datasets =
         metric_defs
@@ -411,28 +468,34 @@ defmodule SelectoComponents.Views.Graph.Component do
             chart_type,
             index,
             data,
-            metric_def.alias,
+            format_metric_label(metric_def, presentation_context),
             drill_down
           )
         end)
 
-      %{labels: labels, datasets: datasets}
+      %{labels: labels, rawLabels: raw_labels, datasets: datasets}
     else
-      labels =
+      label_pairs =
         filtered_results
         |> Enum.map(fn row ->
-          row
-          |> Enum.take(num_x_fields)
-          |> axis_label(x_defs)
+          values = Enum.take(row, num_x_fields)
+
+          %{
+            label: axis_label(values, x_defs, presentation_context),
+            raw_label: raw_axis_label(values, x_defs)
+          }
         end)
-        |> Enum.uniq()
+        |> Enum.uniq_by(& &1.label)
+
+      labels = Enum.map(label_pairs, & &1.label)
+      raw_labels = Enum.map(label_pairs, & &1.raw_label)
 
       series_labels =
         filtered_results
         |> Enum.map(fn row ->
           row
           |> Enum.slice(num_x_fields, num_series_fields)
-          |> axis_label(series_defs)
+          |> axis_label(series_defs, presentation_context)
         end)
         |> Enum.uniq()
 
@@ -447,7 +510,7 @@ defmodule SelectoComponents.Views.Graph.Component do
               Enum.filter(filtered_results, fn row ->
                 row
                 |> Enum.slice(num_x_fields, num_series_fields)
-                |> axis_label(series_defs) == series_label
+                |> axis_label(series_defs, presentation_context) == series_label
               end)
 
             rows_by_label =
@@ -455,7 +518,7 @@ defmodule SelectoComponents.Views.Graph.Component do
                 label =
                   row
                   |> Enum.take(num_x_fields)
-                  |> axis_label(x_defs)
+                  |> axis_label(x_defs, presentation_context)
 
                 {label, row}
               end)
@@ -495,7 +558,9 @@ defmodule SelectoComponents.Views.Graph.Component do
               end)
 
             dataset_offset = metric_index * max(length(series_labels), 1) + series_index
-            dataset_label = "#{metric_def.alias} - #{series_label}"
+
+            dataset_label =
+              "#{format_metric_label(metric_def, presentation_context)} - #{series_label}"
 
             build_cartesian_dataset(
               metric_def,
@@ -508,7 +573,7 @@ defmodule SelectoComponents.Views.Graph.Component do
           end)
         end)
 
-      %{labels: labels, datasets: datasets}
+      %{labels: labels, rawLabels: raw_labels, datasets: datasets}
     end
   end
 
@@ -563,23 +628,56 @@ defmodule SelectoComponents.Views.Graph.Component do
 
   defp group_alias(_), do: "Group"
 
-  defp axis_label(values, group_defs) when is_list(values) and is_list(group_defs) do
+  defp axis_label(values, group_defs, presentation_context)
+       when is_list(values) and is_list(group_defs) do
     values
-    |> axis_value_blocks(group_defs)
+    |> axis_value_blocks(group_defs, presentation_context)
     |> Enum.map(& &1.display)
     |> Enum.reject(&(&1 in [nil, ""]))
     |> Enum.join(" • ")
   end
 
-  defp axis_label(values, _group_defs) when is_list(values) do
+  defp axis_label(values, _group_defs, presentation_context) when is_list(values) do
     values
-    |> Enum.map(&format_chart_label/1)
+    |> Enum.map(&format_chart_label(&1, nil, presentation_context))
     |> Enum.join(" / ")
   end
 
-  defp axis_label(_values, _group_defs), do: ""
+  defp axis_label(_values, _group_defs, _presentation_context), do: ""
 
-  defp axis_value_blocks(values, group_defs) when is_list(values) and is_list(group_defs) do
+  defp raw_axis_label(values, group_defs) when is_list(values) and is_list(group_defs) do
+    case linked_group_ranges(group_defs) do
+      [{0, 0}] ->
+        raw_axis_component(List.first(values), List.first(group_defs))
+
+      ranges ->
+        ranges
+        |> Enum.map(fn {start_idx, end_idx} ->
+          values
+          |> Enum.slice(start_idx, end_idx - start_idx + 1)
+          |> Enum.with_index(start_idx)
+          |> Enum.map(fn {value, idx} ->
+            value
+            |> raw_axis_component(Enum.at(group_defs, idx))
+            |> raw_chart_label()
+          end)
+          |> Enum.join(" • ")
+        end)
+        |> Enum.reject(&(&1 in [nil, ""]))
+        |> Enum.join(" • ")
+    end
+  end
+
+  defp raw_axis_label(values, _group_defs) when is_list(values) do
+    values
+    |> Enum.map(&raw_chart_label/1)
+    |> Enum.join(" / ")
+  end
+
+  defp raw_axis_label(_values, _group_defs), do: ""
+
+  defp axis_value_blocks(values, group_defs, presentation_context)
+       when is_list(values) and is_list(group_defs) do
     linked_group_ranges(group_defs)
     |> Enum.map(fn {start_idx, end_idx} ->
       defs = Enum.slice(group_defs, start_idx, end_idx - start_idx + 1)
@@ -589,14 +687,13 @@ defmodule SelectoComponents.Views.Graph.Component do
         defs: defs,
         values: block_values,
         display:
-          block_values
-          |> Enum.map(&display_value_for_group/1)
-          |> Enum.join(" / ")
+          display_values_for_block(block_values, defs, presentation_context)
+          |> Enum.join(" • ")
       }
     end)
   end
 
-  defp axis_value_blocks(_values, _group_defs), do: []
+  defp axis_value_blocks(_values, _group_defs, _presentation_context), do: []
 
   defp drill_down_specs(values, group_defs) when is_list(values) and is_list(group_defs) do
     Enum.zip(group_defs, values)
@@ -625,11 +722,40 @@ defmodule SelectoComponents.Views.Graph.Component do
 
   defp filter_field_name(_), do: ""
 
-  defp display_value_for_group(value) do
+  defp display_values_for_block(
+         values,
+         defs,
+         presentation_context,
+         formatter \\ &display_value_for_group/3
+       ) do
+    values
+    |> Enum.with_index()
+    |> Enum.map(fn {value, idx} ->
+      formatter.(value, Enum.at(defs, idx), presentation_context)
+    end)
+  end
+
+  defp display_value_for_group(value, %{col: col}, presentation_context) do
     case value do
-      {display_value, _filter_value} -> format_chart_label(display_value)
-      [display_value, _filter_value] -> format_chart_label(display_value)
-      _ -> format_chart_label(value)
+      {display_value, _filter_value} ->
+        format_chart_label(display_value, col, presentation_context)
+
+      [display_value, _filter_value] ->
+        format_chart_label(display_value, col, presentation_context)
+
+      _ ->
+        format_chart_label(value, col, presentation_context)
+    end
+  end
+
+  defp display_value_for_group(value, _group_def, presentation_context),
+    do: format_chart_label(value, nil, presentation_context)
+
+  defp raw_axis_component(value, _group_def) do
+    case value do
+      {display_value, _filter_value} -> display_value
+      [display_value, _filter_value] -> display_value
+      _ -> value
     end
   end
 
@@ -702,7 +828,8 @@ defmodule SelectoComponents.Views.Graph.Component do
          _aliases,
          _x_axis_groups,
          _metric_defs,
-         _series_groups
+         _series_groups,
+         _presentation_context
        ) do
     # Simplified scatter data
     %{
@@ -828,12 +955,15 @@ defmodule SelectoComponents.Views.Graph.Component do
   def get_aggregate_label({:max, field_name}) when is_binary(field_name), do: "max(#{field_name})"
   def get_aggregate_label(_), do: "Value"
 
-  def format_chart_label(value) when is_nil(value), do: "N/A"
+  def format_chart_label(value, column_def \\ nil, presentation_context \\ %{})
 
-  def format_chart_label({value, _meta}) when is_binary(value) or is_number(value),
-    do: normalize_chart_label(value)
+  def format_chart_label(nil, _column_def, _presentation_context), do: "N/A"
 
-  def format_chart_label(value) when is_tuple(value) do
+  def format_chart_label({value, _meta}, column_def, presentation_context)
+      when is_binary(value) or is_number(value),
+      do: display_chart_label(value, column_def, presentation_context)
+
+  def format_chart_label(value, _column_def, _presentation_context) when is_tuple(value) do
     case value do
       {:field, {:count, field_name}, display_name}
       when is_binary(field_name) and is_binary(display_name) ->
@@ -853,10 +983,42 @@ defmodule SelectoComponents.Views.Graph.Component do
     end
   end
 
-  def format_chart_label(value), do: normalize_chart_label(value)
+  def format_chart_label(value, column_def, presentation_context),
+    do: display_chart_label(value, column_def, presentation_context)
+
+  defp display_chart_label(value, column_def, presentation_context) do
+    column_def = maybe_chart_column(column_def)
+
+    if grouped_temporal_value?(column_def) do
+      normalize_chart_label(value)
+    else
+      value
+      |> Presentation.format_cell(column_def, presentation_context)
+      |> normalize_chart_label()
+    end
+  end
+
+  defp raw_chart_label(nil), do: "N/A"
+
+  defp raw_chart_label({value, _meta}) when is_binary(value) or is_number(value),
+    do: normalize_chart_label(value)
+
+  defp raw_chart_label(value), do: normalize_chart_label(value)
 
   defp normalize_chart_label(value) when is_binary(value), do: QueryResults.normalize_value(value)
   defp normalize_chart_label(value), do: to_string(value)
+
+  defp maybe_chart_column(nil), do: nil
+  defp maybe_chart_column(column_def), do: Selecto.Presentation.normalize_column(column_def)
+
+  defp grouped_temporal_value?(column_def) when is_map(column_def) do
+    presentation = Map.get(column_def, :presentation) || %{}
+    temporal? = Map.get(presentation, :semantic_type) == :temporal
+    group_format = Map.get(column_def, :group_format) || Map.get(column_def, "group_format")
+    temporal? and is_binary(group_format) and group_format != ""
+  end
+
+  defp grouped_temporal_value?(_), do: false
 
   def format_numeric_value(value) when is_number(value), do: value
   def format_numeric_value({value, _meta}), do: format_numeric_value(value)
@@ -947,7 +1109,8 @@ defmodule SelectoComponents.Views.Graph.Component do
         alias: Map.get(defn, :alias) || "Value",
         series_type: Map.get(defn, :series_type, "auto"),
         axis: Map.get(defn, :axis, "left"),
-        color: Map.get(defn, :color)
+        color: Map.get(defn, :color),
+        column_def: Map.get(defn, :column_def)
       }
     end)
   end
@@ -958,9 +1121,35 @@ defmodule SelectoComponents.Views.Graph.Component do
         alias: format_aggregate_label(agg),
         series_type: "auto",
         axis: "left",
-        color: nil
+        color: nil,
+        column_def: aggregate_column_def(agg)
       }
     end)
+  end
+
+  defp aggregate_column_def({:field, {_func, field_name}, _alias})
+       when is_binary(field_name) or is_atom(field_name),
+       do: maybe_chart_column(%{colid: field_name})
+
+  defp aggregate_column_def(_), do: nil
+
+  defp format_metric_label(metric_def, presentation_context) do
+    case metric_def do
+      %{alias: alias_name, column_def: column_def} ->
+        unit_label = Presentation.display_unit_label(column_def, presentation_context)
+
+        if is_binary(unit_label) and unit_label != "" do
+          "#{alias_name} (#{unit_label})"
+        else
+          alias_name
+        end
+
+      %{alias: alias_name} ->
+        alias_name
+
+      _ ->
+        "Value"
+    end
   end
 
   defp dataset_type(metric_def, chart_type) do

--- a/lib/selecto_components/views/graph/process.ex
+++ b/lib/selecto_components/views/graph/process.ex
@@ -44,16 +44,17 @@ defmodule SelectoComponents.Views.Graph.Process do
     y_axis_params = Map.get(params, "y_axis", %{})
     series_params = Map.get(params, "series", %{})
     chart_type = Map.get(params, "chart_type", "bar")
+    presentation_context = runtime_presentation_context(params)
 
     # Process X-axis (grouping fields)
-    x_axis_fields = x_axis_params |> group_by_fields(columns)
+    x_axis_fields = x_axis_params |> group_by_fields(columns, presentation_context)
 
     # Process Y-axis (aggregate fields)
     y_axis_defs = y_axis_params |> aggregate_defs(columns)
     y_axis_fields = Enum.map(y_axis_defs, & &1.select_field)
 
     # Process Series (optional secondary grouping)
-    series_fields = series_params |> group_by_fields(columns)
+    series_fields = series_params |> group_by_fields(columns, presentation_context)
 
     # Combine all grouping fields (x_axis + series)
     all_group_by = x_axis_fields ++ series_fields
@@ -86,7 +87,7 @@ defmodule SelectoComponents.Views.Graph.Process do
   @doc """
   Process group by fields (for X-axis and Series)
   """
-  def group_by_fields(field_params, columns) do
+  def group_by_fields(field_params, columns, presentation_context \\ %{}) do
     field_params
     |> Map.values()
     |> Enum.sort(fn a, b -> String.to_integer(a["index"]) <= String.to_integer(b["index"]) end)
@@ -102,6 +103,7 @@ defmodule SelectoComponents.Views.Graph.Process do
             linked? = truthy_param?(Map.get(field_config, "linked_to_next"))
 
             col
+            |> maybe_set_group_format(Map.get(field_config, "format"))
             |> Map.put(:linked_to_next, linked?)
             |> Map.put("linked_to_next", linked?)
           else
@@ -121,7 +123,8 @@ defmodule SelectoComponents.Views.Graph.Process do
           case Selecto.Temporal.date_like_type(col) || col.type do
             x
             when x in [:naive_datetime, :utc_datetime, :naive_datetime_usec, :utc_datetime_usec] ->
-              {:field, datetime_group_by_processor(col, field_config), alias_name}
+              {:field, datetime_group_by_processor(col, field_config, presentation_context),
+               alias_name}
 
             :custom_column ->
               case Map.get(col, :requires_select) do
@@ -152,11 +155,13 @@ defmodule SelectoComponents.Views.Graph.Process do
     |> Enum.map(& &1.select_field)
   end
 
-  def aggregate_defs(aggregate_params, _columns) do
+  def aggregate_defs(aggregate_params, columns) do
     aggregate_params
     |> Map.values()
     |> Enum.sort(fn a, b -> String.to_integer(a["index"]) <= String.to_integer(b["index"]) end)
     |> Enum.map(fn field_config ->
+      column_def = Map.get(columns, field_config["field"])
+
       # Generate alias
       alias_name =
         case field_config["alias"] do
@@ -202,23 +207,37 @@ defmodule SelectoComponents.Views.Graph.Process do
         function: aggregate_function,
         series_type: series_type,
         axis: axis,
-        color: color
+        color: color,
+        column_def: column_def
       }
     end)
   end
 
+  defp maybe_set_group_format(col, format)
+       when is_map(col) and is_binary(format) and format != "" do
+    col
+    |> Map.put(:group_format, format)
+    |> Map.put("group_format", format)
+  end
+
+  defp maybe_set_group_format(col, _format), do: col
+
   # Process datetime fields for grouping (Year, Month, Day, etc.)
-  defp datetime_group_by_processor(col, config) do
+  defp datetime_group_by_processor(col, config, presentation_context) do
     format = config["format"]
     bucket_ranges = config["bucket_ranges"]
+    field_with_alias = graph_field_ref(col.colid)
 
     case format do
       format when format in ~w(YYYY-MM-DD YYYY-WW YYYY-MM YYYY-Q YYYY MM DD D HH24) ->
-        {:to_char, {col.colid, format}}
+        maybe_timezone_aware_datetime_selector(
+          col,
+          field_with_alias,
+          format,
+          presentation_context
+        )
 
       "age_buckets" when is_binary(bucket_ranges) and bucket_ranges != "" ->
-        field_with_alias = graph_field_ref(col.colid)
-
         case_sql =
           BucketParser.generate_bucket_case_sql(
             "(CURRENT_DATE - DATE(#{field_with_alias}))",
@@ -229,8 +248,6 @@ defmodule SelectoComponents.Views.Graph.Process do
         {:raw_sql, case_sql}
 
       "custom_buckets" when is_binary(bucket_ranges) and bucket_ranges != "" ->
-        field_with_alias = graph_field_ref(col.colid)
-
         case_sql =
           BucketParser.generate_bucket_case_sql(
             field_with_alias,
@@ -241,11 +258,9 @@ defmodule SelectoComponents.Views.Graph.Process do
         {:raw_sql, case_sql}
 
       "year_buckets" when is_binary(bucket_ranges) and bucket_ranges != "" ->
-        field_with_alias = graph_field_ref(col.colid)
-
         case_sql =
           BucketParser.generate_bucket_case_sql(
-            "EXTRACT(YEAR FROM #{field_with_alias})",
+            year_bucket_extract_sql(col, field_with_alias, presentation_context),
             bucket_ranges,
             :integer
           )
@@ -261,4 +276,55 @@ defmodule SelectoComponents.Views.Graph.Process do
     colid_str = to_string(colid)
     if String.contains?(colid_str, "."), do: colid_str, else: "selecto_root." <> colid_str
   end
+
+  defp runtime_presentation_context(params) when is_map(params) do
+    Map.get(params, "_presentation_context", %{})
+  end
+
+  defp runtime_presentation_context(_params), do: %{}
+
+  defp maybe_timezone_aware_datetime_selector(col, field_ref, format, presentation_context) do
+    if timezone_grouping_applicable?(col, presentation_context) do
+      {:raw_sql, timezone_aware_to_char_sql(col, field_ref, format, presentation_context)}
+    else
+      {:to_char, {col.colid, format}}
+    end
+  end
+
+  defp year_bucket_extract_sql(col, field_ref, presentation_context) do
+    if timezone_grouping_applicable?(col, presentation_context) do
+      "EXTRACT(YEAR FROM #{timezone_grouping_expression(col, field_ref, presentation_context)})"
+    else
+      "EXTRACT(YEAR FROM #{field_ref})"
+    end
+  end
+
+  defp timezone_grouping_applicable?(col, presentation_context) do
+    Selecto.Presentation.temporal_kind(col) == :instant and
+      is_binary(runtime_timezone(presentation_context)) and
+      runtime_timezone(presentation_context) != ""
+  end
+
+  defp timezone_aware_to_char_sql(col, field_ref, format, presentation_context) do
+    "to_char(#{timezone_grouping_expression(col, field_ref, presentation_context)}, '#{format}')"
+  end
+
+  defp timezone_grouping_expression(col, field_ref, presentation_context) do
+    timezone = runtime_timezone(presentation_context)
+
+    case Selecto.Temporal.epoch_storage(col) do
+      :unix_seconds -> "to_timestamp(#{field_ref}) AT TIME ZONE '#{timezone}'"
+      :unix_milliseconds -> "to_timestamp((#{field_ref}) / 1000.0) AT TIME ZONE '#{timezone}'"
+      _ -> "#{field_ref} AT TIME ZONE '#{timezone}'"
+    end
+  end
+
+  defp runtime_timezone(presentation_context) when is_map(presentation_context) do
+    case Map.get(presentation_context, :timezone, Map.get(presentation_context, "timezone")) do
+      timezone when is_binary(timezone) and timezone != "" -> timezone
+      _ -> nil
+    end
+  end
+
+  defp runtime_timezone(_presentation_context), do: nil
 end

--- a/test/selecto_components/exporter_test.exs
+++ b/test/selecto_components/exporter_test.exs
@@ -257,6 +257,89 @@ defmodule SelectoComponents.ExporterTest do
            ]
   end
 
+  test "formats exports in display mode using presentation metadata" do
+    query_results =
+      {
+        [[0, 1_704_067_200]],
+        ["temperature_c", "recorded_at"],
+        ["Temperature", "Recorded At"]
+      }
+
+    selecto =
+      Selecto.configure(
+        %{
+          name: "ExporterPresentationTest",
+          source: %{
+            source_table: "measurements",
+            primary_key: :id,
+            fields: [:id, :temperature_c, :recorded_at],
+            redact_fields: [],
+            columns: %{
+              id: %{type: :integer},
+              temperature_c: %{
+                type: :decimal,
+                presentation: %{
+                  semantic_type: :measurement,
+                  quantity: :temperature,
+                  canonical_unit: :celsius,
+                  default_unit: :celsius,
+                  format: %{maximum_fraction_digits: 1}
+                }
+              },
+              recorded_at: %{
+                type: :integer,
+                presentation_type: :utc_datetime,
+                datetime_storage: :unix_seconds,
+                presentation: %{
+                  semantic_type: :temporal,
+                  temporal_kind: :instant,
+                  display_timezone: :viewer
+                }
+              }
+            },
+            associations: %{}
+          },
+          schemas: %{},
+          joins: %{}
+        },
+        nil
+      )
+
+    assert {:ok, csv_export} =
+             Exporter.build("csv", query_results,
+               view_mode: :detail,
+               exported_at: @exported_at,
+               selecto: selecto,
+               export_mode: :display,
+               presentation_context: %{unit_system: :us_customary, timezone: "America/New_York"}
+             )
+
+    assert csv_export.content ==
+             "temperature_c,recorded_at\n32.0 F,2023-12-31 19:00"
+
+    assert {:ok, json_export} =
+             Exporter.build("json", query_results,
+               view_mode: :detail,
+               exported_at: @exported_at,
+               selecto: selecto,
+               export_mode: :display,
+               presentation_context: %{unit_system: :us_customary, timezone: "America/New_York"}
+             )
+
+    decoded = Jason.decode!(json_export.content)
+
+    assert decoded["export_mode"] == "display"
+
+    assert decoded["presentation_context"] == %{
+             "timezone" => "America/New_York",
+             "unit_system" => "us_customary"
+           }
+
+    assert decoded["rows"] == [
+             %{"temperature_c" => "32.0 F", "recorded_at" => "2023-12-31 19:00"}
+           ]
+  end
+
   test "returns no_results error for invalid query_results" do
     assert {:error, :no_results} = Exporter.build("csv", nil)
   end

--- a/test/selecto_components/form/filter_rendering_test.exs
+++ b/test/selecto_components/form/filter_rendering_test.exs
@@ -396,6 +396,91 @@ defmodule SelectoComponents.Form.FilterRenderingTest do
     end
   end
 
+  describe "presentation-aware filter inputs" do
+    test "renders canonical measurement filters back in display units" do
+      html =
+        render_component(&FilterRendering.render_standard_filter/1, %{
+          uuid: "f1",
+          section: "filters",
+          index: 0,
+          field_type: :decimal,
+          filter_value: %{
+            "filter" => "temperature_c",
+            "comp" => "=",
+            "value" => "0",
+            "display_value" => "32"
+          },
+          selecto: render_presentation_selecto(),
+          column_def: %{
+            type: :decimal,
+            presentation: %{
+              semantic_type: :measurement,
+              quantity: :temperature,
+              canonical_unit: :celsius,
+              default_unit: :celsius
+            }
+          },
+          filter_def: %{type: :decimal},
+          presentation_context: %{unit_system: :us_customary}
+        })
+
+      assert html =~ ~s(value="32")
+    end
+
+    test "renders canonical instant datetime filters in viewer local time" do
+      html =
+        render_component(&FilterRendering.render_datetime_filter/1, %{
+          uuid: "f1",
+          section: "filters",
+          index: 0,
+          field_type: :utc_datetime,
+          filter_value: %{
+            "filter" => "recorded_at",
+            "comp" => ">=",
+            "value" => "2024-01-01T12:00:00Z",
+            "display_value" => "2024-01-01T07:00"
+          },
+          selecto: render_presentation_selecto(),
+          column_def: %{
+            type: :integer,
+            presentation_type: :utc_datetime,
+            datetime_storage: :unix_seconds,
+            presentation: %{
+              semantic_type: :temporal,
+              temporal_kind: :instant,
+              display_timezone: :viewer
+            }
+          },
+          filter_def: %{type: :utc_datetime},
+          presentation_context: %{timezone: "America/New_York"}
+        })
+
+      assert html =~ ~s(value="2024-01-01T07:00")
+    end
+
+    test "renders canonical plain numeric filters back in display-local form" do
+      html =
+        render_component(&FilterRendering.render_standard_filter/1, %{
+          uuid: "f1",
+          section: "filters",
+          index: 0,
+          field_type: :decimal,
+          filter_value: %{
+            "filter" => "amount",
+            "comp" => ">=",
+            "value" => "1234.5",
+            "display_value" => "1.234,5"
+          },
+          selecto: render_presentation_selecto(),
+          column_def: %{type: :decimal},
+          filter_def: %{type: :decimal},
+          presentation_context: %{locale: "de-DE"}
+        })
+
+      assert html =~ ~s(value="1.234,5")
+    end
+  end
+
   describe "Security notes" do
     test "documents security measures for filter rendering" do
       # Security measures in FilterRendering:
@@ -425,6 +510,54 @@ defmodule SelectoComponents.Form.FilterRenderingTest do
         columns: %{
           id: %{type: :integer, colid: :id, name: "ID"},
           status: %{type: :string, colid: :status, name: "Status"}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{}
+    }
+
+    Selecto.configure(domain, nil)
+  end
+
+  defp render_presentation_selecto do
+    domain = %{
+      name: "FilterRenderingPresentationTest",
+      source: %{
+        source_table: "records",
+        primary_key: :id,
+        fields: [:id, :temperature_c, :recorded_at, :amount],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer, colid: :id, name: "ID"},
+          temperature_c: %{
+            type: :decimal,
+            colid: :temperature_c,
+            name: "Temperature",
+            presentation: %{
+              semantic_type: :measurement,
+              quantity: :temperature,
+              canonical_unit: :celsius,
+              default_unit: :celsius
+            }
+          },
+          recorded_at: %{
+            type: :integer,
+            colid: :recorded_at,
+            name: "Recorded At",
+            presentation_type: :utc_datetime,
+            datetime_storage: :unix_seconds,
+            presentation: %{
+              semantic_type: :temporal,
+              temporal_kind: :instant,
+              display_timezone: :viewer
+            }
+          },
+          amount: %{
+            type: :decimal,
+            colid: :amount,
+            name: "Amount"
+          }
         },
         associations: %{}
       },

--- a/test/selecto_components/form/params_state_test.exs
+++ b/test/selecto_components/form/params_state_test.exs
@@ -21,12 +21,55 @@ defmodule SelectoComponents.Form.ParamsStateTest do
       source: %{
         source_table: "records",
         primary_key: :id,
-        fields: [:id, :status, :priority],
+        fields: [:id, :status, :priority, :amount],
         redact_fields: [],
         columns: %{
           id: %{type: :integer, name: "ID"},
           status: %{type: :string, name: "Status"},
-          priority: %{type: :integer, name: "Priority"}
+          priority: %{type: :integer, name: "Priority"},
+          amount: %{type: :decimal, name: "Amount"}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{}
+    }
+
+    Selecto.configure(domain, nil)
+  end
+
+  defp presentation_selecto do
+    domain = %{
+      name: "ParamsStatePresentationTest",
+      source: %{
+        source_table: "records",
+        primary_key: :id,
+        fields: [:id, :temperature_c, :recorded_at],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer},
+          temperature_c: %{
+            type: :decimal,
+            presentation: %{
+              semantic_type: :measurement,
+              quantity: :temperature,
+              canonical_unit: :celsius,
+              default_unit: :celsius,
+              format: %{maximum_fraction_digits: 1}
+            }
+          },
+          recorded_at: %{
+            type: :integer,
+            presentation_type: :utc_datetime,
+            datetime_storage: :unix_seconds,
+            presentation: %{
+              semantic_type: :temporal,
+              temporal_kind: :instant,
+              display_timezone: :viewer
+            }
+          },
+          priority: %{type: :integer, name: "Priority"},
+          amount: %{type: :decimal, name: "Amount"}
         },
         associations: %{}
       },
@@ -198,7 +241,14 @@ defmodule SelectoComponents.Form.ParamsStateTest do
       }
     }
 
-    updated = ParamsState.form_params_to_state(params, base_socket())
+    updated =
+      params
+      |> then(
+        &ParamsState.form_params_to_state(
+          &1,
+          base_socket() |> Phoenix.Component.assign(:selecto, presentation_selecto())
+        )
+      )
 
     assert updated.assigns.view_config.ctes == [
              {"auto-cte-active_delivery_projects", "active_delivery_projects", %{}}
@@ -217,7 +267,15 @@ defmodule SelectoComponents.Form.ParamsStateTest do
       }
     }
 
-    updated = ParamsState.form_params_to_state(params, base_socket())
+    updated =
+      params
+      |> then(
+        &ParamsState.form_params_to_state(
+          &1,
+          base_socket() |> Phoenix.Component.assign(:selecto, presentation_selecto())
+        )
+      )
+
     encoded = ParamsState.view_config_to_params(updated.assigns.view_config)
 
     assert encoded["ctes"]["k0"]["name"] == "active_delivery_projects"
@@ -388,6 +446,60 @@ defmodule SelectoComponents.Form.ParamsStateTest do
     [{"f1", "filters", filter}] = updated.assigns.view_config.filters
 
     assert filter["value"] == "last_week"
+  end
+
+  test "params_to_state canonicalizes measurement filter values while preserving display input" do
+    socket =
+      base_socket()
+      |> Phoenix.Component.assign(:selecto, presentation_selecto())
+      |> Phoenix.Component.assign(:presentation_context, %{unit_system: :us_customary})
+
+    params = %{
+      "view_mode" => "detail",
+      "filters" => %{
+        "f1" => %{
+          "filter" => "temperature_c",
+          "comp" => "=",
+          "value" => "32",
+          "index" => "0",
+          "section" => "filters",
+          "uuid" => "f1"
+        }
+      }
+    }
+
+    updated = ParamsState.params_to_state(params, socket)
+    [{"f1", "filters", filter}] = updated.assigns.view_config.filters
+
+    assert filter["value"] == "0"
+    assert filter["display_value"] == "32"
+  end
+
+  test "params_to_state canonicalizes instant datetime filters from viewer timezone" do
+    socket =
+      base_socket()
+      |> Phoenix.Component.assign(:selecto, presentation_selecto())
+      |> Phoenix.Component.assign(:presentation_context, %{timezone: "America/New_York"})
+
+    params = %{
+      "view_mode" => "detail",
+      "filters" => %{
+        "f1" => %{
+          "filter" => "recorded_at",
+          "comp" => ">=",
+          "value" => "2024-01-01T07:00",
+          "index" => "0",
+          "section" => "filters",
+          "uuid" => "f1"
+        }
+      }
+    }
+
+    updated = ParamsState.params_to_state(params, socket)
+    [{"f1", "filters", filter}] = updated.assigns.view_config.filters
+
+    assert filter["value"] == "2024-01-01T12:00:00Z"
+    assert filter["display_value"] == "2024-01-01T07:00"
   end
 
   test "params_to_state preserves detail row click action when params omit it" do
@@ -1195,6 +1307,129 @@ defmodule SelectoComponents.Form.ParamsStateTest do
     refute Map.has_key?(canonicalized, "promoted_filters")
   end
 
+  test "canonicalize_form_params parses locale-aware measurement values when units differ" do
+    params = %{
+      "filters" => %{
+        "k0" => %{
+          "filter" => "temperature_c",
+          "comp" => "=",
+          "value" => "32,5 F"
+        }
+      }
+    }
+
+    canonicalized =
+      ParamsState.canonicalize_form_params(
+        params,
+        presentation_selecto(),
+        %{locale: "de-DE", unit_system: :us_customary}
+      )
+
+    assert canonicalized["filters"]["k0"]["display_value"] == "32,5 F"
+    assert canonicalized["filters"]["k0"]["value"] == "0.277777777778"
+  end
+
+  test "canonicalize_form_params normalizes locale-aware measurement values even when unit stays canonical" do
+    params = %{
+      "filters" => %{
+        "k0" => %{
+          "filter" => "temperature_c",
+          "comp" => "BETWEEN",
+          "value_start" => "1.234,5",
+          "value_end" => "2.345,5"
+        }
+      }
+    }
+
+    canonicalized =
+      ParamsState.canonicalize_form_params(
+        params,
+        presentation_selecto(),
+        %{locale: "de-DE", unit_system: :metric}
+      )
+
+    assert canonicalized["filters"]["k0"]["display_value_start"] == "1.234,5"
+    assert canonicalized["filters"]["k0"]["display_value_end"] == "2.345,5"
+    assert canonicalized["filters"]["k0"]["value_start"] == "1234.5"
+    assert canonicalized["filters"]["k0"]["value_end"] == "2345.5"
+  end
+
+  test "canonicalize_form_params honors explicit numeric conventions overrides for measurements" do
+    params = %{
+      "filters" => %{
+        "k0" => %{
+          "filter" => "temperature_c",
+          "comp" => "=",
+          "value" => "1.234,5"
+        }
+      }
+    }
+
+    canonicalized =
+      ParamsState.canonicalize_form_params(
+        params,
+        presentation_selecto(),
+        %{
+          locale: "en-US",
+          unit_system: :metric,
+          conventions: %{decimal_separator: ",", grouping_separators: [".", " "]}
+        }
+      )
+
+    assert canonicalized["filters"]["k0"]["value"] == "1234.5"
+  end
+
+  test "canonicalize_form_params parses locale-aware plain numeric values" do
+    params = %{
+      "filters" => %{
+        "k0" => %{
+          "filter" => "amount",
+          "comp" => "BETWEEN",
+          "value_start" => "1.234,5",
+          "value_end" => "2.345,5"
+        }
+      }
+    }
+
+    canonicalized =
+      ParamsState.canonicalize_form_params(
+        params,
+        selecto(),
+        %{locale: "de-DE"}
+      )
+
+    assert canonicalized["filters"]["k0"]["display_value_start"] == "1.234,5"
+    assert canonicalized["filters"]["k0"]["display_value_end"] == "2.345,5"
+    assert canonicalized["filters"]["k0"]["value_start"] == "1234.5"
+    assert canonicalized["filters"]["k0"]["value_end"] == "2345.5"
+  end
+
+  test "params_to_state preserves display-local plain numeric filter input" do
+    socket =
+      base_socket()
+      |> Phoenix.Component.assign(:presentation_context, %{locale: "de-DE"})
+
+    params = %{
+      "view_mode" => "detail",
+      "filters" => %{
+        "f1" => %{
+          "filter" => "amount",
+          "comp" => ">=",
+          "value" => "1.234,5",
+          "index" => "0",
+          "section" => "filters",
+          "uuid" => "f1"
+        }
+      }
+    }
+
+    updated = ParamsState.params_to_state(params, socket)
+    [{"f1", "filters", filter}] = updated.assigns.view_config.filters
+
+    assert filter["value"] == "1234.5"
+    assert filter["display_value"] == "1.234,5"
+  end
+
   test "canonicalize_form_params normalizes promoted non-equals controller values" do
     params = %{
       "filters" => %{
@@ -1263,6 +1498,22 @@ defmodule SelectoComponents.Form.ParamsStateTest do
 
     assert Map.has_key?(compacted["group_by"], "k0")
     assert compacted["group_by"]["k0"]["uuid"] == "12b1e264-6359-4f7d-881a-f3c659fd8606"
+  end
+
+  test "compact_url_params leaves runtime presentation context untouched" do
+    params = %{
+      "view_mode" => "graph",
+      "x_axis" => %{
+        "axis-1" => %{"field" => "created_at", "index" => "0"}
+      },
+      "_presentation_context" => %{"timezone" => "America/New_York"}
+    }
+
+    compacted = ParamsState.compact_url_params(params)
+
+    assert compacted["view_mode"] == "graph"
+    assert compacted["x_axis"]["k0"]["field"] == "created_at"
+    assert compacted["_presentation_context"]["timezone"] == "America/New_York"
   end
 
   test "view_config_to_params includes map scalar config" do

--- a/test/selecto_components/presentation_test.exs
+++ b/test/selecto_components/presentation_test.exs
@@ -3,6 +3,28 @@ defmodule SelectoComponents.PresentationTest do
 
   alias SelectoComponents.Presentation
 
+  defmodule TestLocaleAdapter do
+    @behaviour SelectoComponents.Presentation.LocaleAdapter
+
+    @impl true
+    def parse_number("1|234~5", _context), do: {:ok, 1234.5}
+    def parse_number(_value, _context), do: :error
+
+    @impl true
+    def format_number(value, _context, opts) do
+      digits = Keyword.get(opts, :digits, 2)
+
+      formatted =
+        case value do
+          float when is_float(float) -> :erlang.float_to_binary(float, decimals: digits)
+          integer when is_integer(integer) -> Integer.to_string(integer)
+          _ -> to_string(value)
+        end
+
+      {:ok, "adapter:" <> formatted}
+    end
+  end
+
   test "formats measurements using viewer unit preferences" do
     column = %{
       presentation: %{
@@ -48,5 +70,51 @@ defmodule SelectoComponents.PresentationTest do
 
     assert Presentation.format_value(12.5, column, %{unit_system: :us_customary}, mode: :raw) ==
              12.5
+  end
+
+  test "parses locale-aware numeric strings using inferred locale conventions" do
+    assert Presentation.parse_number("1.234,5", %{locale: "de-DE"}) == 1234.5
+    assert Presentation.parse_number("1 234,5", %{locale: "fr-FR"}) == 1234.5
+    assert Presentation.parse_number("1,234.5", %{locale: "en-US"}) == 1234.5
+  end
+
+  test "parses numeric strings using explicit conventions overrides" do
+    context = %{
+      locale: "en-US",
+      conventions: %{
+        decimal_separator: ",",
+        grouping_separators: [".", " "]
+      }
+    }
+
+    assert Presentation.parse_number("1.234,5", context) == 1234.5
+  end
+
+  test "parses numbers through a custom locale adapter when configured" do
+    context = %{locale_adapter: TestLocaleAdapter}
+
+    assert Presentation.parse_number("1|234~5", context) == 1234.5
+  end
+
+  test "formats numbers through a custom locale adapter when configured" do
+    column = %{
+      presentation: %{
+        semantic_type: :measurement,
+        quantity: :temperature,
+        canonical_unit: :celsius,
+        default_unit: :celsius,
+        format: %{maximum_fraction_digits: 1}
+      }
+    }
+
+    context = %{locale_adapter: TestLocaleAdapter}
+
+    assert Presentation.format_cell(12.5, column, context, show_unit: false) == "adapter:12.5"
+  end
+
+  test "falls back to built-in parsing when locale adapter does not handle a value" do
+    context = %{locale: "de-DE", locale_adapter: TestLocaleAdapter}
+
+    assert Presentation.parse_number("1.234,5", context) == 1234.5
   end
 end

--- a/test/selecto_components/presentation_test.exs
+++ b/test/selecto_components/presentation_test.exs
@@ -1,0 +1,52 @@
+defmodule SelectoComponents.PresentationTest do
+  use ExUnit.Case, async: true
+
+  alias SelectoComponents.Presentation
+
+  test "formats measurements using viewer unit preferences" do
+    column = %{
+      presentation: %{
+        semantic_type: :measurement,
+        quantity: :temperature,
+        canonical_unit: :celsius,
+        default_unit: :celsius,
+        format: %{maximum_fraction_digits: 1}
+      }
+    }
+
+    context = %{unit_system: :us_customary}
+
+    assert Presentation.display_unit(column, context) == :fahrenheit
+    assert Presentation.display_unit_label(column, context) == "F"
+    assert Presentation.format_cell(0, column, context) == "32.0 F"
+  end
+
+  test "formats epoch-backed temporal values in the requested timezone" do
+    column = %{
+      type: :integer,
+      presentation_type: :utc_datetime,
+      datetime_storage: :unix_seconds,
+      presentation: %{
+        semantic_type: :temporal,
+        temporal_kind: :instant,
+        display_timezone: :viewer
+      }
+    }
+
+    assert Presentation.format_cell(1_704_067_200, column, %{timezone: "America/New_York"}) ==
+             "2023-12-31 19:00"
+  end
+
+  test "raw mode preserves original values" do
+    column = %{
+      presentation: %{
+        semantic_type: :measurement,
+        quantity: :distance,
+        canonical_unit: :kilometer
+      }
+    }
+
+    assert Presentation.format_value(12.5, column, %{unit_system: :us_customary}, mode: :raw) ==
+             12.5
+  end
+end

--- a/test/selecto_components/presentation_test.exs
+++ b/test/selecto_components/presentation_test.exs
@@ -23,6 +23,20 @@ defmodule SelectoComponents.PresentationTest do
 
       {:ok, "adapter:" <> formatted}
     end
+
+    @impl true
+    def format_temporal(%Date{} = value, _context, _opts),
+      do: {:ok, "date:" <> Date.to_iso8601(value)}
+
+    def format_temporal(%DateTime{} = value, _context, _opts) do
+      {:ok, "datetime:" <> Calendar.strftime(value, "%d/%m/%Y %H:%M")}
+    end
+
+    def format_temporal(%NaiveDateTime{} = value, _context, _opts) do
+      {:ok, "naive:" <> Calendar.strftime(value, "%d/%m/%Y %H:%M")}
+    end
+
+    def format_temporal(_value, _context, _opts), do: :error
   end
 
   test "formats measurements using viewer unit preferences" do
@@ -57,6 +71,35 @@ defmodule SelectoComponents.PresentationTest do
 
     assert Presentation.format_cell(1_704_067_200, column, %{timezone: "America/New_York"}) ==
              "2023-12-31 19:00"
+  end
+
+  test "formats temporal values through a custom locale adapter when configured" do
+    column = %{
+      type: :integer,
+      presentation_type: :utc_datetime,
+      datetime_storage: :unix_seconds,
+      presentation: %{
+        semantic_type: :temporal,
+        temporal_kind: :instant,
+        display_timezone: :viewer
+      }
+    }
+
+    context = %{timezone: "America/New_York", locale_adapter: TestLocaleAdapter}
+
+    assert Presentation.format_cell(1_704_067_200, column, context) ==
+             "datetime:31/12/2023 19:00"
+  end
+
+  test "formats date values through a custom locale adapter when configured" do
+    column = %{
+      type: :date,
+      presentation: %{semantic_type: :temporal, temporal_kind: :date}
+    }
+
+    context = %{locale_adapter: TestLocaleAdapter}
+
+    assert Presentation.format_cell(~D[2024-01-02], column, context) == "date:2024-01-02"
   end
 
   test "raw mode preserves original values" do
@@ -110,6 +153,24 @@ defmodule SelectoComponents.PresentationTest do
     context = %{locale_adapter: TestLocaleAdapter}
 
     assert Presentation.format_cell(12.5, column, context, show_unit: false) == "adapter:12.5"
+  end
+
+  test "falls back to built-in temporal formatting when locale adapter does not handle a value" do
+    column = %{
+      type: :integer,
+      presentation_type: :utc_datetime,
+      datetime_storage: :unix_seconds,
+      presentation: %{
+        semantic_type: :temporal,
+        temporal_kind: :instant,
+        display_timezone: :viewer
+      }
+    }
+
+    context = %{timezone: "America/New_York", locale_adapter: TestLocaleAdapter}
+
+    assert Presentation.format_cell("2024-01-01T12:00:00Z", column, context) ==
+             "2024-01-01T12:00:00Z"
   end
 
   test "falls back to built-in parsing when locale adapter does not handle a value" do

--- a/test/selecto_components/views/aggregate/component_test.exs
+++ b/test/selecto_components/views/aggregate/component_test.exs
@@ -740,4 +740,78 @@ defmodule SelectoComponents.Views.Aggregate.ComponentTest do
     assert html =~ "Friday"
     refute html =~ ">6<"
   end
+
+  test "renders presentation-formatted aggregate values and group labels" do
+    selecto =
+      Selecto.configure(
+        %{
+          name: "AggregatePresentationTest",
+          source: %{
+            source_table: "records",
+            primary_key: :id,
+            fields: [:id, :temperature_c, :recorded_at],
+            redact_fields: [],
+            columns: %{
+              id: %{type: :integer},
+              temperature_c: %{
+                type: :decimal,
+                presentation: %{
+                  semantic_type: :measurement,
+                  quantity: :temperature,
+                  canonical_unit: :celsius,
+                  default_unit: :celsius,
+                  format: %{maximum_fraction_digits: 1}
+                }
+              },
+              recorded_at: %{
+                type: :integer,
+                presentation_type: :utc_datetime,
+                datetime_storage: :unix_seconds,
+                presentation: %{
+                  semantic_type: :temporal,
+                  temporal_kind: :instant,
+                  display_timezone: :viewer
+                }
+              }
+            },
+            associations: %{}
+          },
+          schemas: %{},
+          joins: %{}
+        },
+        nil
+      )
+
+    assigns = %{
+      id: "aggregate-presentation-test",
+      executed: true,
+      execution_error: nil,
+      view_config: %{
+        view_mode: "aggregate",
+        filters: [],
+        group_by: %{
+          "g0" => %{"field" => "recorded_at", "index" => "0"}
+        }
+      },
+      selecto: %{
+        selecto
+        | set: %{
+            selected: [
+              {:field, :recorded_at, "recorded_at"},
+              {:field, {:avg, :temperature_c}, "avg_temperature_c"}
+            ],
+            group_by: [{:rollup, [{:literal_position, 1}]}],
+            aggregates: [{:field, {:avg, :temperature_c}, "avg_temperature_c"}]
+          }
+      },
+      query_results: {[[1_704_067_200, 0]], [], ["recorded_at", "avg_temperature_c"]},
+      view_meta: %{exe_id: "aggregate-presentation-run"},
+      presentation_context: %{unit_system: :us_customary, timezone: "America/New_York"}
+    }
+
+    html = render_component(Component, assigns)
+
+    assert html =~ "2023-12-31 19:00"
+    assert html =~ "32.0 F"
+  end
 end

--- a/test/selecto_components/views/aggregate/process_test.exs
+++ b/test/selecto_components/views/aggregate/process_test.exs
@@ -193,6 +193,93 @@ defmodule SelectoComponents.Views.Aggregate.ProcessTest do
     assert sql =~ "CASE WHEN"
   end
 
+  test "group by uses viewer timezone for instant datetime formatting" do
+    columns = %{
+      "created_at" => %{
+        name: "Created At",
+        type: :utc_datetime,
+        colid: :created_at,
+        presentation: %{
+          semantic_type: :temporal,
+          temporal_kind: :instant,
+          display_timezone: :viewer
+        }
+      }
+    }
+
+    [{_col, selector}] =
+      Process.group_by(
+        %{"g1" => %{"field" => "created_at", "format" => "YYYY-MM", "index" => "0"}},
+        columns,
+        nil,
+        %{timezone: "America/New_York"}
+      )
+
+    assert {:field, {:raw_sql, sql}, "Created At"} = selector
+    assert sql == "to_char(selecto_root.created_at AT TIME ZONE 'America/New_York', 'YYYY-MM')"
+  end
+
+  test "group by uses viewer timezone for epoch-backed instant year buckets" do
+    columns = %{
+      "occurred_at_epoch" => %{
+        name: "Occurred At",
+        type: :integer,
+        colid: :occurred_at_epoch,
+        presentation_type: :utc_datetime,
+        datetime_storage: :unix_seconds,
+        presentation: %{
+          semantic_type: :temporal,
+          temporal_kind: :instant,
+          display_timezone: :viewer
+        }
+      }
+    }
+
+    [{_col, selector}] =
+      Process.group_by(
+        %{
+          "g1" => %{
+            "field" => "occurred_at_epoch",
+            "format" => "year_buckets",
+            "bucket_ranges" => "*/5",
+            "index" => "0"
+          }
+        },
+        columns,
+        nil,
+        %{timezone: "America/New_York"}
+      )
+
+    assert {:field, {:raw_sql, sql}, "Occurred At"} = selector
+
+    assert sql =~
+             "EXTRACT(YEAR FROM to_timestamp(selecto_root.occurred_at_epoch) AT TIME ZONE 'America/New_York')"
+  end
+
+  test "group by leaves naive datetime formatting unchanged" do
+    columns = %{
+      "created_at" => %{
+        name: "Created At",
+        type: :naive_datetime,
+        colid: :created_at,
+        presentation: %{
+          semantic_type: :temporal,
+          temporal_kind: :naive_datetime
+        }
+      }
+    }
+
+    [{_col, selector}] =
+      Process.group_by(
+        %{"g1" => %{"field" => "created_at", "format" => "YYYY-MM", "index" => "0"}},
+        columns,
+        nil,
+        %{timezone: "America/New_York"}
+      )
+
+    assert {:field, {:to_char, {:created_at, "YYYY-MM"}}, "Created At"} = selector
+  end
+
   test "group by preserves joined field references for datetime year buckets" do
     columns = %{
       "delivery_team.inserted_at" => %{

--- a/test/selecto_components/views/detail/component_test.exs
+++ b/test/selecto_components/views/detail/component_test.exs
@@ -173,6 +173,68 @@ defmodule SelectoComponents.Views.Detail.ComponentTest do
     assert html =~ "{{2026, 3, 17}, {8, 0, 0, 0}}"
   end
 
+  test "renders presentation-formatted detail values" do
+    detail_selecto =
+      Selecto.configure(
+        %{
+          name: "DetailPresentationTest",
+          source: %{
+            source_table: "records",
+            primary_key: :id,
+            fields: [:id, :temperature_c, :recorded_at],
+            redact_fields: [],
+            columns: %{
+              id: %{type: :integer},
+              temperature_c: %{
+                type: :decimal,
+                presentation: %{
+                  semantic_type: :measurement,
+                  quantity: :temperature,
+                  canonical_unit: :celsius,
+                  default_unit: :celsius,
+                  format: %{maximum_fraction_digits: 1}
+                }
+              },
+              recorded_at: %{
+                type: :integer,
+                presentation_type: :utc_datetime,
+                datetime_storage: :unix_seconds,
+                presentation: %{
+                  semantic_type: :temporal,
+                  temporal_kind: :instant,
+                  display_timezone: :viewer
+                }
+              }
+            },
+            associations: %{}
+          },
+          schemas: %{},
+          joins: %{}
+        },
+        nil
+      )
+      |> Map.put(:set, %{
+        columns: [
+          %{"field" => "temperature_c", "alias" => "temperature_c", "uuid" => "temp-col"},
+          %{"field" => "recorded_at", "alias" => "recorded_at", "uuid" => "recorded-col"}
+        ]
+      })
+
+    assigns =
+      base_assigns(%{
+        selecto: detail_selecto,
+        query_results:
+          {[[0, 1_704_067_200]], ["temperature_c", "recorded_at"], ["Temperature", "Recorded At"]},
+        view_meta: %{page: 0, per_page: 10, total_rows: 1, subselect_configs: []},
+        presentation_context: %{unit_system: :us_customary, timezone: "America/New_York"}
+      })
+
+    html = render_component(Component, assigns)
+
+    assert html =~ "32.0 F"
+    assert html =~ "2023-12-31 19:00"
+  end
+
   test "renders row values when column uuid does not match row-data uuid mapping" do
     assigns =
       base_assigns(%{

--- a/test/selecto_components/views/graph/component_test.exs
+++ b/test/selecto_components/views/graph/component_test.exs
@@ -137,6 +137,42 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
       assert chart_data.datasets == []
     end
 
+    test "formats graph labels with presentation context and preserves raw labels" do
+      assigns = %{
+        selecto: %{
+          set: %{
+            x_axis_groups: [
+              {%{
+                 colid: :recorded_at,
+                 type: :integer,
+                 presentation_type: :utc_datetime,
+                 datetime_storage: :unix_seconds,
+                 presentation: %{
+                   semantic_type: :temporal,
+                   temporal_kind: :instant,
+                   display_timezone: :viewer
+                 }
+               }, {:field, :recorded_at, "Recorded At"}}
+            ],
+            aggregates: [
+              {:field, {:count, "film_id"}, "Film Count"}
+            ],
+            series_groups: [],
+            chart_type: "bar"
+          }
+        },
+        presentation_context: %{timezone: "America/New_York"}
+      }
+
+      results = [[1_704_067_200, 30]]
+      aliases = ["Recorded At", "Film Count"]
+
+      chart_data = Component.prepare_chart_data(assigns, results, aliases)
+
+      assert chart_data.labels == ["2023-12-31 19:00"]
+      assert chart_data.rawLabels == [1_704_067_200]
+    end
+
     test "collapses linked x-axis fields into grouped labels and drill-down specs" do
       assigns = %{
         selecto: %{
@@ -161,7 +197,8 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
 
       chart_data = Component.prepare_chart_data(assigns, results, ["State", "Title", "Count"])
 
-      assert chart_data.labels == ["done / ES", "todo / BU"]
+      assert chart_data.labels == ["done • ES", "todo • BU"]
+      assert chart_data.rawLabels == ["done • ES", "todo • BU"]
 
       [dataset] = chart_data.datasets
       assert dataset.data == [32, 14]
@@ -209,7 +246,7 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
       assert length(chart_data.datasets) == 1
 
       [dataset] = chart_data.datasets
-      assert dataset.label == "Count - 0-4 / software_engineer"
+      assert dataset.label == "Count - 0-4 • software_engineer"
       assert dataset.data == [32, 10]
 
       assert dataset.drillDown == [
@@ -224,6 +261,51 @@ defmodule SelectoComponents.Views.Graph.ComponentTest do
                  %{field: "assignee_role", value: "software_engineer", gidx: "2"}
                ]
              ]
+    end
+
+    test "adds measurement unit to metric labels when presentation metadata is available" do
+      assigns = %{
+        selecto: %{
+          set: %{
+            x_axis_groups: [
+              {%{colid: :category, type: :string}, {:field, :category, "Category"}}
+            ],
+            aggregates: [
+              {:field, {:avg, "temperature_c"}, "Average Temperature"}
+            ],
+            graph_series_defs: [
+              %{
+                alias: "Average Temperature",
+                series_type: "auto",
+                axis: "left",
+                color: nil,
+                column_def: %{
+                  colid: :temperature_c,
+                  type: :decimal,
+                  presentation: %{
+                    semantic_type: :measurement,
+                    quantity: :temperature,
+                    canonical_unit: :celsius,
+                    default_unit: :celsius,
+                    format: %{maximum_fraction_digits: 1}
+                  }
+                }
+              }
+            ],
+            series_groups: [],
+            chart_type: "line"
+          }
+        },
+        presentation_context: %{unit_system: :us_customary}
+      }
+
+      results = [["Action", 0]]
+      aliases = ["Category", "Average Temperature"]
+
+      chart_data = Component.prepare_chart_data(assigns, results, aliases)
+
+      [dataset] = chart_data.datasets
+      assert dataset.label == "Average Temperature (F)"
     end
   end
 

--- a/test/selecto_components/views/graph/process_test.exs
+++ b/test/selecto_components/views/graph/process_test.exs
@@ -275,6 +275,45 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
       assert {:field, {:to_char, {:created_at, "YYYY-Q"}}, "Quarter"} = field_selector
     end
 
+    test "uses viewer timezone for instant datetime graph grouping", %{columns: columns} do
+      datetime_columns =
+        Map.put(columns, "created_at", %{
+          colid: :created_at,
+          type: :utc_datetime,
+          presentation: %{
+            semantic_type: :temporal,
+            temporal_kind: :instant,
+            display_timezone: :viewer
+          }
+        })
+
+      params = %{
+        "x_axis" => %{
+          "1" => %{
+            "field" => "created_at",
+            "index" => "0",
+            "alias" => "Month",
+            "format" => "YYYY-MM"
+          }
+        },
+        "y_axis" => %{
+          "1" => %{
+            "field" => "film_count",
+            "index" => "0",
+            "function" => "count",
+            "alias" => "Count"
+          }
+        },
+        "_presentation_context" => %{"timezone" => "America/New_York"}
+      }
+
+      {view_set, _} = Process.view(nil, params, datetime_columns, [], nil)
+      [{_col, field_selector}] = view_set.x_axis_groups
+
+      assert {:field, {:raw_sql, sql}, "Month"} = field_selector
+      assert sql == "to_char(selecto_root.created_at AT TIME ZONE 'America/New_York', 'YYYY-MM')"
+    end
+
     test "supports year buckets in graph grouping", %{columns: columns} do
       datetime_columns =
         Map.put(columns, "created_at", %{colid: :created_at, type: :utc_datetime})
@@ -304,6 +343,50 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
 
       assert {:field, {:raw_sql, sql}, "Year Buckets"} = field_selector
       assert sql =~ "EXTRACT(YEAR FROM selecto_root.created_at)"
+    end
+
+    test "uses viewer timezone for instant year buckets in graph grouping", %{columns: columns} do
+      datetime_columns =
+        Map.put(columns, "occurred_at_epoch", %{
+          colid: :occurred_at_epoch,
+          type: :integer,
+          presentation_type: :utc_datetime,
+          datetime_storage: :unix_seconds,
+          presentation: %{
+            semantic_type: :temporal,
+            temporal_kind: :instant,
+            display_timezone: :viewer
+          }
+        })
+
+      params = %{
+        "x_axis" => %{
+          "1" => %{
+            "field" => "occurred_at_epoch",
+            "index" => "0",
+            "alias" => "Year Buckets",
+            "format" => "year_buckets",
+            "bucket_ranges" => "*/5"
+          }
+        },
+        "y_axis" => %{
+          "1" => %{
+            "field" => "film_count",
+            "index" => "0",
+            "function" => "count",
+            "alias" => "Count"
+          }
+        },
+        "_presentation_context" => %{"timezone" => "America/New_York"}
+      }
+
+      {view_set, _} = Process.view(nil, params, datetime_columns, [], nil)
+      [{_col, field_selector}] = view_set.x_axis_groups
+
+      assert {:field, {:raw_sql, sql}, "Year Buckets"} = field_selector
+
+      assert sql =~
+               "EXTRACT(YEAR FROM to_timestamp(selecto_root.occurred_at_epoch) AT TIME ZONE 'America/New_York')"
     end
 
     test "generates proper order_by and group_by clauses", %{columns: columns} do
@@ -365,7 +448,7 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
     end
   end
 
-  describe "group_by_fields/2" do
+  describe "group_by_fields/3" do
     setup do
       columns = %{
         "category" => %{colid: :category, type: :string},
@@ -399,6 +482,18 @@ defmodule SelectoComponents.Views.Graph.ProcessTest do
       }
 
       result = Process.group_by_fields(field_params, columns)
+
+      [{col, field_selector}] = result
+      assert col.colid == :created_at
+      assert field_selector == {:field, {:to_char, {:created_at, "YYYY"}}, "Year"}
+    end
+
+    test "keeps naive datetime grouping unchanged when timezone is present", %{columns: columns} do
+      field_params = %{
+        "1" => %{"field" => "created_at", "index" => "0", "alias" => "Year", "format" => "YYYY"}
+      }
+
+      result = Process.group_by_fields(field_params, columns, %{timezone: "America/New_York"})
 
       [{col, field_selector}] = result
       assert col.colid == :created_at


### PR DESCRIPTION
This pull request introduces a new "export mode" feature for data exports, allowing users to choose between "raw" and "display" modes for exported data. The changes span backend, frontend, and export logic, providing both UI controls and deep integration with presentation formatting. Additionally, the export panel and event handling have been updated to support and propagate this new option across download and email export workflows.

**Export Mode Support and Data Formatting:**

* Added support for an `export_mode` option throughout the export pipeline, including UI controls in the export panel, event handlers, and backend processing. Users can now select between "raw" (original data) and "display" (formatted data) modes for exports. [[1]](diffhunk://#diff-f3e42ca9c7674b2eea920a2971c4272176eb297d47453905a1678e7ffd1061bdL34-R52) [[2]](diffhunk://#diff-f3e42ca9c7674b2eea920a2971c4272176eb297d47453905a1678e7ffd1061bdR106-R119) [[3]](diffhunk://#diff-f3e42ca9c7674b2eea920a2971c4272176eb297d47453905a1678e7ffd1061bdR161) [[4]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R354-R386) [[5]](diffhunk://#diff-e15b1e89e5fc92c14b6b4dd657f11ffac9b0fde82a61f6413bc35383bf15be53L27-R38) [[6]](diffhunk://#diff-e15b1e89e5fc92c14b6b4dd657f11ffac9b0fde82a61f6413bc35383bf15be53R99-R101) [[7]](diffhunk://#diff-e15b1e89e5fc92c14b6b4dd657f11ffac9b0fde82a61f6413bc35383bf15be53R208-R210) [[8]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6R39-R46) [[9]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6R360-R363) [[10]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L71-R86) [[11]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L86-R99)

* The backend export logic (`SelectoComponents.Exporter.Dataset`) has been updated to use the appropriate presentation formatting for each cell based on the selected export mode, leveraging the `Presentation.format_value/4` function.

**Frontend Integration and UI Enhancements:**

* The export panel UI now includes a dropdown for selecting export mode for both download and email exports, and all export buttons are wired to pass the selected mode to the backend. [[1]](diffhunk://#diff-f3e42ca9c7674b2eea920a2971c4272176eb297d47453905a1678e7ffd1061bdL34-R52) [[2]](diffhunk://#diff-f3e42ca9c7674b2eea920a2971c4272176eb297d47453905a1678e7ffd1061bdR106-R119) [[3]](diffhunk://#diff-f3e42ca9c7674b2eea920a2971c4272176eb297d47453905a1678e7ffd1061bdR161) [[4]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R354-R386) [[5]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R337-R344)

* Refactored export download button handling in the frontend JavaScript to support multiple buttons and proper cleanup, mirroring the email export logic. [[1]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R354-R386) [[2]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R311-R314)

**Context Propagation and Consistency:**

* The `presentation_context` is now consistently passed through assigns and export options, ensuring that formatting context is available wherever needed (including for filters and exports). [[1]](diffhunk://#diff-8e1e17d58f4ceb57d2aa758132f569347a735ca029b22b62d5e90b20b6e68330R73) [[2]](diffhunk://#diff-e15b1e89e5fc92c14b6b4dd657f11ffac9b0fde82a61f6413bc35383bf15be53R99-R101) [[3]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L71-R86) [[4]](diffhunk://#diff-e2a7ac1469151e6a433985a0bfca166314b030c3b5699a282a6b422f47ba4ab6R39-R46)

**Filter Rendering Improvements:**

* Refactored filter rendering to use a new `filter_input_value/4` function, supporting the use of `presentation_context` for consistent formatting of filter input values. [[1]](diffhunk://#diff-2b8912f771b2329334182ea03b886ee26cd4e2602156df3408c92a231e8f8235L242-R247) [[2]](diffhunk://#diff-2b8912f771b2329334182ea03b886ee26cd4e2602156df3408c92a231e8f8235L255-R262) [[3]](diffhunk://#diff-2b8912f771b2329334182ea03b886ee26cd4e2602156df3408c92a231e8f8235L463-R473) [[4]](diffhunk://#diff-2b8912f771b2329334182ea03b886ee26cd4e2602156df3408c92a231e8f8235R19)

**Internal Refactoring and Option Handling:**

* Refactored dataset building and row normalization to support the new export mode and presentation context, including column definition lookup and value formatting logic. [[1]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L18-R20) [[2]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L71-R86) [[3]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44L288-R406) [[4]](diffhunk://#diff-255d50427df41cc0c292d808cebc57ea39e36d7857881f883f6c23abc4df6a44R4-R5)

These changes enable more flexible and user-friendly exports, allowing for both raw data extraction and exports that match the on-screen presentation.