### PR TITLE
Wire capability decisions into action forms

### DIFF
--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -44,6 +44,9 @@ defmodule SelectoComponents.Actions do
 
   - `:scope` filters actions to a scope such as `:row` or `"bulk"`
   - `:decisions` supplies `%{"action_id" => decision}` or `%{"capability" => decision}`
+  - `:capability_resolver` supplies a host-owned resolver function invoked with a
+    `%Selecto.Capabilities.Request{}` for actions that declare a capability
+  - `:actor`, `:tenant`, `:domain`, and `:context` are copied into resolver requests
   - `:default_status` defaults to `"enabled"`
   """
   @spec available(term(), keyword()) :: [action_item()]
@@ -54,7 +57,7 @@ defmodule SelectoComponents.Actions do
 
     contract
     |> action_entries()
-    |> Enum.map(&action_item(&1, decisions, default_status))
+    |> Enum.map(&action_item(&1, decisions, default_status, opts))
     |> Enum.reject(& &1.hidden?)
     |> Enum.filter(fn item -> is_nil(scope) or item.scope == scope end)
   end
@@ -205,11 +208,13 @@ defmodule SelectoComponents.Actions do
         decision -> %{(action |> map_value(:id) |> normalize_id()) => decision}
       end
 
+    available_opts =
+      opts
+      |> Keyword.put(:decisions, Keyword.get(opts, :decisions, decisions))
+      |> Keyword.put(:default_status, Keyword.get(opts, :default_status, "enabled"))
+
     %{"actions" => [action]}
-    |> available(
-      decisions: Keyword.get(opts, :decisions, decisions),
-      default_status: Keyword.get(opts, :default_status, "enabled")
-    )
+    |> available(available_opts)
     |> List.first()
   end
 
@@ -365,9 +370,9 @@ defmodule SelectoComponents.Actions do
 
   defp put_links(action, _links), do: action
 
-  defp action_item(action, decisions, default_status) do
+  defp action_item(action, decisions, default_status, opts) do
     action = SelectoComponents.QueryContract.json_safe(map_or_empty(action))
-    decision = decision_for(action, decisions, default_status)
+    decision = availability_decision(action, decisions, default_status, opts)
     status = normalize_status(map_value(decision, :status))
 
     %{
@@ -397,6 +402,101 @@ defmodule SelectoComponents.Actions do
       attrs: action_attrs(action, status),
       contract: action
     }
+  end
+
+  defp availability_decision(action, decisions, default_status, opts) do
+    explicit_decision = explicit_decision_for(action, decisions)
+    resolver_decision = resolver_decision_for(action, opts)
+
+    explicit_decision
+    |> merge_resolver_decision(resolver_decision)
+    |> normalize_decision(default_status)
+  end
+
+  defp explicit_decision_for(action, decisions) do
+    action_id = action |> map_value(:id) |> normalize_id()
+    capability = action |> map_value(:capability) |> normalize_optional_id()
+
+    map_lookup(decisions, action_id) ||
+      map_lookup(decisions, capability) ||
+      map_value(action, :capability_decision)
+  end
+
+  defp resolver_decision_for(action, opts) do
+    capability = action |> map_value(:capability) |> normalize_optional_id()
+    resolver = Keyword.get(opts, :capability_resolver)
+
+    cond do
+      is_nil(capability) ->
+        nil
+
+      is_function(resolver, 1) ->
+        action
+        |> capability_request(opts)
+        |> resolver.()
+        |> unwrap_resolver_decision()
+
+      is_function(resolver, 2) ->
+        request = capability_request(action, opts)
+        resolver_context = Keyword.get(opts, :resolver_context, %{})
+
+        request
+        |> resolver.(resolver_context)
+        |> unwrap_resolver_decision()
+
+      true ->
+        nil
+    end
+  end
+
+  defp capability_request(action, opts) do
+    capability = action |> map_value(:capability) |> normalize_id()
+
+    Selecto.Capabilities.request(
+      actor: Keyword.get(opts, :actor),
+      tenant: Keyword.get(opts, :tenant),
+      domain: Keyword.get(opts, :domain),
+      capability: capability,
+      operation:
+        Keyword.get(opts, :operation) ||
+          action_operation(action) ||
+          :execute_action,
+      target: Keyword.get(opts, :target, %{}),
+      context:
+        opts
+        |> Keyword.get(:context, %{})
+        |> map_or_empty()
+        |> Map.merge(%{
+          action_id: action |> map_value(:id) |> normalize_id(),
+          action_scope: action |> map_value(:scope) |> normalize_optional_id(),
+          surface: Keyword.get(opts, :surface, :components)
+        }),
+      metadata:
+        opts
+        |> Keyword.get(:metadata, %{})
+        |> map_or_empty()
+    )
+  end
+
+  defp unwrap_resolver_decision({:ok, decision}), do: decision
+
+  defp unwrap_resolver_decision({:error, reason}),
+    do: %{status: :disabled, reason: inspect(reason)}
+
+  defp unwrap_resolver_decision(decision), do: decision
+
+  defp merge_resolver_decision(nil, nil), do: nil
+  defp merge_resolver_decision(explicit_decision, nil), do: explicit_decision
+  defp merge_resolver_decision(nil, resolver_decision), do: resolver_decision
+
+  defp merge_resolver_decision(explicit_decision, resolver_decision) do
+    explicit = normalize_decision(explicit_decision, "enabled")
+    resolver = normalize_decision(resolver_decision, "enabled")
+
+    case normalize_status(map_value(resolver, :status)) do
+      "enabled" -> explicit
+      _status -> Map.merge(explicit, resolver)
+    end
   end
 
   defp action_label(action) do
@@ -610,9 +710,23 @@ defmodule SelectoComponents.Actions do
     %{"status" => normalize_status(status)}
   end
 
+  defp normalize_decision(%Selecto.Capabilities.Decision{} = decision, _default_status) do
+    %{
+      "status" => decision_status(decision),
+      "reason" => decision.user_message || decision.audit_reason,
+      "code" => decision.reason_code,
+      "effects" => decision.effects,
+      "obligations" => decision.obligations,
+      "metadata" => decision.metadata
+    }
+    |> compact_decision()
+    |> SelectoComponents.QueryContract.json_safe()
+  end
+
   defp normalize_decision(decision, default_status) when is_map(decision) do
     decision
     |> SelectoComponents.QueryContract.json_safe()
+    |> normalize_capability_decision_map(default_status)
     |> Map.put_new("status", normalize_status(default_status))
   end
 
@@ -635,9 +749,36 @@ defmodule SelectoComponents.Actions do
   end
 
   defp normalize_status(status) when status in [:enabled, "enabled"], do: "enabled"
+  defp normalize_status(status) when status in [:allow, "allow"], do: "enabled"
   defp normalize_status(status) when status in [:disabled, "disabled"], do: "disabled"
+  defp normalize_status(status) when status in [:deny, "deny"], do: "disabled"
+  defp normalize_status(status) when status in [:conditional, "conditional"], do: "disabled"
+  defp normalize_status(status) when status in [:preview_only, "preview_only"], do: "disabled"
   defp normalize_status(status) when status in [:hidden, "hidden"], do: "hidden"
+  defp normalize_status(status) when status in [:not_applicable, "not_applicable"], do: "hidden"
   defp normalize_status(_status), do: "enabled"
+
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :hidden}), do: "hidden"
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :disabled}), do: "disabled"
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :preview_only}), do: "disabled"
+
+  defp decision_status(%Selecto.Capabilities.Decision{status: status}),
+    do: normalize_status(status)
+
+  defp normalize_capability_decision_map(decision, default_status) do
+    decision
+    |> Map.update("status", normalize_status(default_status), &normalize_status/1)
+    |> put_reason_from_capability_message()
+  end
+
+  defp put_reason_from_capability_message(decision) do
+    reason =
+      map_value(decision, :reason) ||
+        map_value(decision, :user_message) ||
+        map_value(decision, :audit_reason)
+
+    maybe_put(decision, "reason", reason)
+  end
 
   defp normalize_id(nil), do: ""
   defp normalize_id(value) when is_atom(value), do: Atom.to_string(value)

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -226,7 +226,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="preview"
             data-selecto-action-form-submit="preview"
-            class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            class={action_submit_class(:preview, @disabled? || @applied? || @submitting == "preview")}
             disabled={@disabled? || @applied? || @submitting == "preview"}
           >
             Preview
@@ -236,7 +236,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="apply"
             data-selecto-action-form-submit="apply"
-            class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            class={action_submit_class(:apply, apply_disabled?(@confirmation, @confirmed, @submitting, @applied?, @disabled?))}
             disabled={apply_disabled?(@confirmation, @confirmed, @submitting, @applied?, @disabled?)}
           >
             Apply
@@ -513,6 +513,18 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp apply_disabled?(confirmation, confirmed, submitting, applied?, disabled?) do
     disabled? or applied? or submitting == "apply" or
       (truthy?(Map.get(confirmation, "required")) and not confirmed)
+  end
+
+  defp action_submit_class(_intent, true) do
+    "rounded border border-slate-300 bg-slate-100 px-3 py-2 text-sm font-medium text-slate-400 opacity-80 cursor-not-allowed"
+  end
+
+  defp action_submit_class(:preview, false) do
+    "rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+  end
+
+  defp action_submit_class(:apply, false) do
+    "rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
   end
 
   defp disabled_action?(action) do

--- a/lib/selecto_components/views/detail/form.ex
+++ b/lib/selecto_components/views/detail/form.ex
@@ -57,7 +57,11 @@ defmodule SelectoComponents.Views.Detail.Form do
       )
       |> normalize_checkbox_value()
 
-    row_action_options = RowActions.available_actions(assigns.selecto)
+    row_action_options =
+      RowActions.available_actions(
+        assigns.selecto,
+        Map.get(assigns, :row_action_availability_opts, [])
+      )
 
     selected_row_action =
       Enum.find(row_action_options, fn action -> action.id == row_click_action end)

--- a/lib/selecto_components/views/detail/row_actions.ex
+++ b/lib/selecto_components/views/detail/row_actions.ex
@@ -10,8 +10,8 @@ defmodule SelectoComponents.Views.Detail.RowActions do
   def default_modal_action_id, do: @default_modal_action_id
   def generated_action_form_prefix, do: @generated_action_form_prefix
 
-  def available_actions(selecto) do
-    [default_modal_action() | registered_actions(selecto)]
+  def available_actions(selecto, opts \\ []) do
+    [default_modal_action() | registered_actions(selecto, opts)]
   end
 
   def current_action(selecto, row_click_action, opts \\ []) do
@@ -29,7 +29,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
         Map.put(default_modal_action(), :source, :configured)
 
       true ->
-        registered_actions(selecto)
+        registered_actions(selecto, opts)
         |> Enum.find(fn action -> action.id == action_id end)
         |> case do
           nil -> nil
@@ -166,12 +166,12 @@ defmodule SelectoComponents.Views.Detail.RowActions do
 
   def resolve_component_assigns(_assigns_template, _source), do: %{}
 
-  defp registered_actions(selecto) do
+  defp registered_actions(selecto, opts) do
     domain = Selecto.domain(selecto)
 
     domain
     |> registered_detail_actions()
-    |> Kernel.++(generated_action_forms(domain))
+    |> Kernel.++(generated_action_forms(domain, opts))
     |> Enum.map(&normalize_action/1)
     |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(&String.downcase(&1.name))
@@ -185,12 +185,17 @@ defmodule SelectoComponents.Views.Detail.RowActions do
 
   defp registered_detail_actions(_domain), do: %{}
 
-  defp generated_action_forms(domain) when is_map(domain) do
+  defp generated_action_forms(domain, opts) when is_map(domain) do
     domain
     |> Actions.detail_actions(
-      id_prefix: @generated_action_form_prefix,
-      required_fields: [:id],
-      target: %{id: {:field, "id"}}
+      Keyword.merge(
+        [
+          id_prefix: @generated_action_form_prefix,
+          required_fields: [:id],
+          target: %{id: {:field, "id"}}
+        ],
+        opts
+      )
     )
     |> Enum.map(fn {id, config} -> {id, Map.put(config, :source, :generated_action_form)} end)
     |> Enum.filter(fn {_id, config} ->
@@ -203,7 +208,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
     end)
   end
 
-  defp generated_action_forms(_domain), do: []
+  defp generated_action_forms(_domain, _opts), do: []
 
   defp normalize_action({action_id, action_config}) when is_map(action_config) do
     type = normalize_action_type(map_get(action_config, :type))

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -90,6 +90,56 @@ defmodule SelectoComponents.ActionsTest do
     assert action.reason == "Approval window is closed"
   end
 
+  test "uses host capability resolver decisions for action availability" do
+    resolver = fn request ->
+      assert %Selecto.Capabilities.Request{} = request
+      assert request.capability == "orders.approve"
+      assert request.operation == "update"
+      assert request.context.surface == :components
+      assert request.context.action_id == "approve_order"
+
+      Selecto.Capabilities.deny(:missing_role, user_message: "Managers only")
+    end
+
+    assert [action] =
+             Actions.available(write_contract(),
+               actor: %{id: 1, role: :analyst},
+               domain: :orders,
+               capability_resolver: resolver
+             )
+
+    assert action.id == "approve_order"
+    assert action.status == "disabled"
+    assert action.disabled? == true
+    assert action.reason == "Managers only"
+  end
+
+  test "filters resolver-hidden actions" do
+    actions =
+      Actions.available(write_contract(),
+        capability_resolver: fn _request ->
+          Selecto.Capabilities.hidden(:not_visible, user_message: "Not visible here")
+        end
+      )
+
+    assert actions == []
+  end
+
+  test "keeps target disabled decisions when host policy allows the action" do
+    assert [action] =
+             Actions.available(write_contract(),
+               decisions: %{
+                 "approve_order" => %{status: :disabled, reason: "Target is already closed"}
+               },
+               capability_resolver: fn _request ->
+                 Selecto.Capabilities.allow(:role_allowed, user_message: "Allowed by role")
+               end
+             )
+
+    assert action.status == "disabled"
+    assert action.reason == "Target is already closed"
+  end
+
   test "filters hidden actions and can scope visible actions" do
     contract =
       write_contract(%{

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -67,6 +67,8 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~r/name="confirmed"[\s\S]*disabled/
     assert html =~ ~r/value="preview"[\s\S]*disabled/
     assert html =~ ~r/value="apply"[\s\S]*disabled/
+    assert html =~ ~r/value="preview"[\s\S]*bg-slate-100[\s\S]*disabled/
+    assert html =~ ~r/value="apply"[\s\S]*bg-slate-100[\s\S]*disabled/
   end
 
   test "render exposes stable action metadata and submit hooks" do

--- a/test/selecto_components/views/detail/form_test.exs
+++ b/test/selecto_components/views/detail/form_test.exs
@@ -118,6 +118,72 @@ defmodule SelectoComponents.Views.Detail.FormTest do
     assert html =~ "apply: /work-items/actions/archive/apply"
   end
 
+  test "filters generated row action form choices through capability resolver" do
+    domain = %{
+      name: "DetailFormPolicyActionsTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :title],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer, name: "ID", colid: :id},
+          title: %{type: :string, name: "Title", colid: :title}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      detail_actions: %{},
+      actions: %{
+        archive: %{
+          id: :archive,
+          label: "Archive",
+          scope: :row,
+          capability: "work_items.archive",
+          execution: %{operation: :update}
+        },
+        set_estimate: %{
+          id: :set_estimate,
+          label: "Set estimate",
+          scope: :row,
+          capability: "work_items.estimation",
+          execution: %{operation: :update}
+        }
+      }
+    }
+
+    html =
+      render_component(Form, %{
+        id: "detail-form-policy-actions-test",
+        columns: [{:id, "ID", :integer}, {:title, "Title", :string}],
+        view: {:detail, SelectoComponents.Views.Detail, "Detail", %{}},
+        selecto: Selecto.configure(domain, nil),
+        row_action_availability_opts: [
+          capability_resolver: fn
+            %{capability: "work_items.archive"} ->
+              Selecto.Capabilities.hidden(:not_visible)
+
+            _request ->
+              Selecto.Capabilities.allow(:allowed)
+          end
+        ],
+        view_config: %{
+          views: %{
+            detail: %{
+              selected: [],
+              order_by: [],
+              row_click_action: ""
+            }
+          }
+        }
+      })
+
+    refute html =~ ~s(value="domain_action_form_archive")
+    assert html =~ ~s(value="domain_action_form_set_estimate")
+    assert html =~ "Set estimate"
+  end
+
   test "uses detail config as the only row click action source while editing" do
     domain = %{
       name: "DetailFormParamsTest",


### PR DESCRIPTION
This pull request introduces a flexible capability-based action availability system, allowing host applications to control which actions are visible or enabled based on custom policy logic. The changes add support for a capability resolver function, improve normalization of action statuses, and ensure that UI components and tests reflect these new policies.

**Key improvements:**

### Capability-based Action Availability

* Added support for a `:capability_resolver` option to `SelectoComponents.Actions.available/2`, allowing host applications to supply a resolver function that determines the availability of actions based on capabilities and context. The resolver receives a `%Selecto.Capabilities.Request{}` and can return allow/deny/hidden decisions. (`lib/selecto_components/actions.ex` [[1]](diffhunk://#diff-d216003628e95866de9ef02fdc2b49bd8e118a818667aa0af713c5346bf1e988R47-R49) [[2]](diffhunk://#diff-d216003628e95866de9ef02fdc2b49bd8e118a818667aa0af713c5346bf1e988R407-R501) [[3]](diffhunk://#diff-d216003628e95866de9ef02fdc2b49bd8e118a818667aa0af713c5346bf1e988R713-R729) [[4]](diffhunk://#diff-113c01c5d2536b9f03c27875541d354bd1ef39b8cdc5de087764a1b0685f7e74R93-R142)
* The resolver request includes contextual information such as `:actor`, `:tenant`, `:domain`, and `:context`, enabling fine-grained, policy-driven action control. (`lib/selecto_components/actions.ex` [lib/selecto_components/actions.exR407-R501](diffhunk://#diff-d216003628e95866de9ef02fdc2b49bd8e118a818667aa0af713c5346bf1e988R407-R501))

### Action Status Normalization

* Improved normalization of action statuses: new status mappings (e.g., `:allow` → `"enabled"`, `:deny`, `:conditional`, `:preview_only` → `"disabled"`, `:not_applicable` → `"hidden"`), and better handling of capability decision objects. (`lib/selecto_components/actions.ex` [lib/selecto_components/actions.exR752-R782](diffhunk://#diff-d216003628e95866de9ef02fdc2b49bd8e118a818667aa0af713c5346bf1e988R752-R782))
* Merged explicit and resolver-based decisions, ensuring that explicit (target-level) disables take precedence over policy allows, and that hidden actions are filtered out. (`lib/selecto_components/actions.ex` [lib/selecto_components/actions.exR407-R501](diffhunk://#diff-d216003628e95866de9ef02fdc2b49bd8e118a818667aa0af713c5346bf1e988R407-R501))

### UI and Component Integration

* Updated modal form submit buttons to use a helper (`action_submit_class/2`) that applies appropriate styling and disabled state based on action availability, improving accessibility and consistency. (`lib/selecto_components/modal/action_form_modal.ex` [[1]](diffhunk://#diff-78e52839fde3e2c5769e5b89e9304a056392b7efcc6d40032281611e986a5559L229-R229) [[2]](diffhunk://#diff-78e52839fde3e2c5769e5b89e9304a056392b7efcc6d40032281611e986a5559L239-R239) [[3]](diffhunk://#diff-78e52839fde3e2c5769e5b89e9304a056392b7efcc6d40032281611e986a5559R518-R529)
* Passed capability resolver options through row action selection logic, so generated row actions in detail views are filtered according to policy. (`lib/selecto_components/views/detail/form.ex` [[1]](diffhunk://#diff-b2150eb882743122a1b7830066c540440e8e111851894839dd4e67bce09d8ceaL60-R64) `lib/selecto_components/views/detail/row_actions.ex` [[2]](diffhunk://#diff-b66075cfcd97c13b53235ecd3be3cb7ad85cc8d598478134fd7e409cde399a0cL13-R14) [[3]](diffhunk://#diff-b66075cfcd97c13b53235ecd3be3cb7ad85cc8d598478134fd7e409cde399a0cL32-R32) [[4]](diffhunk://#diff-b66075cfcd97c13b53235ecd3be3cb7ad85cc8d598478134fd7e409cde399a0cL169-R174) [[5]](diffhunk://#diff-b66075cfcd97c13b53235ecd3be3cb7ad85cc8d598478134fd7e409cde399a0cL188-R198) [[6]](diffhunk://#diff-b66075cfcd97c13b53235ecd3be3cb7ad85cc8d598478134fd7e409cde399a0cL206-R211)

### Testing and Validation

* Added comprehensive tests for capability resolver integration, including scenarios for allow/deny/hidden decisions, merging of explicit and resolver decisions, and UI-level filtering of unavailable actions. (`test/selecto_components/actions_test.exs` [[1]](diffhunk://#diff-113c01c5d2536b9f03c27875541d354bd1ef39b8cdc5de087764a1b0685f7e74R93-R142) `test/selecto_components/views/detail/form_test.exs` [[2]](diffhunk://#diff-8b2f16b0b50b0a58f49b2d5fa64a9001b3761c4358aa82b1edab4e8698e0e110R121-R186) `test/selecto_components/modal/action_form_modal_test.exs` [[3]](diffhunk://#diff-ce6b636b6d84f3746ae6b7927a62d3cbde4a09a91ba92651733fccde44f96be1R70-R71)

---

These changes make action availability highly customizable and policy-driven, supporting advanced authorization and UI filtering scenarios.