### PR TITLE
Project query capability policy into contracts

### DIFF
--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -44,6 +44,9 @@ defmodule SelectoComponents.Actions do
 
   - `:scope` filters actions to a scope such as `:row` or `"bulk"`
   - `:decisions` supplies `%{"action_id" => decision}` or `%{"capability" => decision}`
+  - `:capability_resolver` supplies a host-owned resolver function invoked with a
+    `%Selecto.Capabilities.Request{}` for actions that declare a capability
+  - `:actor`, `:tenant`, `:domain`, and `:context` are copied into resolver requests
   - `:default_status` defaults to `"enabled"`
   """
   @spec available(term(), keyword()) :: [action_item()]
@@ -54,7 +57,7 @@ defmodule SelectoComponents.Actions do
 
     contract
     |> action_entries()
-    |> Enum.map(&action_item(&1, decisions, default_status))
+    |> Enum.map(&action_item(&1, decisions, default_status, opts))
     |> Enum.reject(& &1.hidden?)
     |> Enum.filter(fn item -> is_nil(scope) or item.scope == scope end)
   end
@@ -205,11 +208,13 @@ defmodule SelectoComponents.Actions do
         decision -> %{(action |> map_value(:id) |> normalize_id()) => decision}
       end
 
+    available_opts =
+      opts
+      |> Keyword.put(:decisions, Keyword.get(opts, :decisions, decisions))
+      |> Keyword.put(:default_status, Keyword.get(opts, :default_status, "enabled"))
+
     %{"actions" => [action]}
-    |> available(
-      decisions: Keyword.get(opts, :decisions, decisions),
-      default_status: Keyword.get(opts, :default_status, "enabled")
-    )
+    |> available(available_opts)
     |> List.first()
   end
 
@@ -365,9 +370,9 @@ defmodule SelectoComponents.Actions do
 
   defp put_links(action, _links), do: action
 
-  defp action_item(action, decisions, default_status) do
+  defp action_item(action, decisions, default_status, opts) do
     action = SelectoComponents.QueryContract.json_safe(map_or_empty(action))
-    decision = decision_for(action, decisions, default_status)
+    decision = availability_decision(action, decisions, default_status, opts)
     status = normalize_status(map_value(decision, :status))
 
     %{
@@ -397,6 +402,101 @@ defmodule SelectoComponents.Actions do
       attrs: action_attrs(action, status),
       contract: action
     }
+  end
+
+  defp availability_decision(action, decisions, default_status, opts) do
+    explicit_decision = explicit_decision_for(action, decisions)
+    resolver_decision = resolver_decision_for(action, opts)
+
+    explicit_decision
+    |> merge_resolver_decision(resolver_decision)
+    |> normalize_decision(default_status)
+  end
+
+  defp explicit_decision_for(action, decisions) do
+    action_id = action |> map_value(:id) |> normalize_id()
+    capability = action |> map_value(:capability) |> normalize_optional_id()
+
+    map_lookup(decisions, action_id) ||
+      map_lookup(decisions, capability) ||
+      map_value(action, :capability_decision)
+  end
+
+  defp resolver_decision_for(action, opts) do
+    capability = action |> map_value(:capability) |> normalize_optional_id()
+    resolver = Keyword.get(opts, :capability_resolver)
+
+    cond do
+      is_nil(capability) ->
+        nil
+
+      is_function(resolver, 1) ->
+        action
+        |> capability_request(opts)
+        |> resolver.()
+        |> unwrap_resolver_decision()
+
+      is_function(resolver, 2) ->
+        request = capability_request(action, opts)
+        resolver_context = Keyword.get(opts, :resolver_context, %{})
+
+        request
+        |> resolver.(resolver_context)
+        |> unwrap_resolver_decision()
+
+      true ->
+        nil
+    end
+  end
+
+  defp capability_request(action, opts) do
+    capability = action |> map_value(:capability) |> normalize_id()
+
+    Selecto.Capabilities.request(
+      actor: Keyword.get(opts, :actor),
+      tenant: Keyword.get(opts, :tenant),
+      domain: Keyword.get(opts, :domain),
+      capability: capability,
+      operation:
+        Keyword.get(opts, :operation) ||
+          action_operation(action) ||
+          :execute_action,
+      target: Keyword.get(opts, :target, %{}),
+      context:
+        opts
+        |> Keyword.get(:context, %{})
+        |> map_or_empty()
+        |> Map.merge(%{
+          action_id: action |> map_value(:id) |> normalize_id(),
+          action_scope: action |> map_value(:scope) |> normalize_optional_id(),
+          surface: Keyword.get(opts, :surface, :components)
+        }),
+      metadata:
+        opts
+        |> Keyword.get(:metadata, %{})
+        |> map_or_empty()
+    )
+  end
+
+  defp unwrap_resolver_decision({:ok, decision}), do: decision
+
+  defp unwrap_resolver_decision({:error, reason}),
+    do: %{status: :disabled, reason: inspect(reason)}
+
+  defp unwrap_resolver_decision(decision), do: decision
+
+  defp merge_resolver_decision(nil, nil), do: nil
+  defp merge_resolver_decision(explicit_decision, nil), do: explicit_decision
+  defp merge_resolver_decision(nil, resolver_decision), do: resolver_decision
+
+  defp merge_resolver_decision(explicit_decision, resolver_decision) do
+    explicit = normalize_decision(explicit_decision, "enabled")
+    resolver = normalize_decision(resolver_decision, "enabled")
+
+    case normalize_status(map_value(resolver, :status)) do
+      "enabled" -> explicit
+      _status -> Map.merge(explicit, resolver)
+    end
   end
 
   defp action_label(action) do
@@ -610,9 +710,23 @@ defmodule SelectoComponents.Actions do
     %{"status" => normalize_status(status)}
   end
 
+  defp normalize_decision(%Selecto.Capabilities.Decision{} = decision, _default_status) do
+    %{
+      "status" => decision_status(decision),
+      "reason" => decision.user_message || decision.audit_reason,
+      "code" => decision.reason_code,
+      "effects" => decision.effects,
+      "obligations" => decision.obligations,
+      "metadata" => decision.metadata
+    }
+    |> compact_decision()
+    |> SelectoComponents.QueryContract.json_safe()
+  end
+
   defp normalize_decision(decision, default_status) when is_map(decision) do
     decision
     |> SelectoComponents.QueryContract.json_safe()
+    |> normalize_capability_decision_map(default_status)
     |> Map.put_new("status", normalize_status(default_status))
   end
 
@@ -635,9 +749,36 @@ defmodule SelectoComponents.Actions do
   end
 
   defp normalize_status(status) when status in [:enabled, "enabled"], do: "enabled"
+  defp normalize_status(status) when status in [:allow, "allow"], do: "enabled"
   defp normalize_status(status) when status in [:disabled, "disabled"], do: "disabled"
+  defp normalize_status(status) when status in [:deny, "deny"], do: "disabled"
+  defp normalize_status(status) when status in [:conditional, "conditional"], do: "disabled"
+  defp normalize_status(status) when status in [:preview_only, "preview_only"], do: "disabled"
   defp normalize_status(status) when status in [:hidden, "hidden"], do: "hidden"
+  defp normalize_status(status) when status in [:not_applicable, "not_applicable"], do: "hidden"
   defp normalize_status(_status), do: "enabled"
+
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :hidden}), do: "hidden"
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :disabled}), do: "disabled"
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :preview_only}), do: "disabled"
+
+  defp decision_status(%Selecto.Capabilities.Decision{status: status}),
+    do: normalize_status(status)
+
+  defp normalize_capability_decision_map(decision, default_status) do
+    decision
+    |> Map.update("status", normalize_status(default_status), &normalize_status/1)
+    |> put_reason_from_capability_message()
+  end
+
+  defp put_reason_from_capability_message(decision) do
+    reason =
+      map_value(decision, :reason) ||
+        map_value(decision, :user_message) ||
+        map_value(decision, :audit_reason)
+
+    maybe_put(decision, "reason", reason)
+  end
 
   defp normalize_id(nil), do: ""
   defp normalize_id(value) when is_atom(value), do: Atom.to_string(value)

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -226,7 +226,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="preview"
             data-selecto-action-form-submit="preview"
-            class="rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            class={action_submit_class(:preview, @disabled? || @applied? || @submitting == "preview")}
             disabled={@disabled? || @applied? || @submitting == "preview"}
           >
             Preview
@@ -236,7 +236,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
             name="intent"
             value="apply"
             data-selecto-action-form-submit="apply"
-            class="rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50"
+            class={action_submit_class(:apply, apply_disabled?(@confirmation, @confirmed, @submitting, @applied?, @disabled?))}
             disabled={apply_disabled?(@confirmation, @confirmed, @submitting, @applied?, @disabled?)}
           >
             Apply
@@ -513,6 +513,18 @@ defmodule SelectoComponents.Modal.ActionFormModal do
   defp apply_disabled?(confirmation, confirmed, submitting, applied?, disabled?) do
     disabled? or applied? or submitting == "apply" or
       (truthy?(Map.get(confirmation, "required")) and not confirmed)
+  end
+
+  defp action_submit_class(_intent, true) do
+    "rounded border border-slate-300 bg-slate-100 px-3 py-2 text-sm font-medium text-slate-400 opacity-80 cursor-not-allowed"
+  end
+
+  defp action_submit_class(:preview, false) do
+    "rounded bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+  end
+
+  defp action_submit_class(:apply, false) do
+    "rounded bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700"
   end
 
   defp disabled_action?(action) do

--- a/lib/selecto_components/query_contract.ex
+++ b/lib/selecto_components/query_contract.ex
@@ -11,6 +11,7 @@ defmodule SelectoComponents.QueryContract do
   alias SelectoComponents.Form.ChoiceSourceMetadata
   alias SelectoComponents.QueryContract.IntentValidator
   alias SelectoComponents.QueryContract.Links
+  alias SelectoComponents.QueryContract.Policy
 
   @query_contract_version 1
   @default_context %{
@@ -89,6 +90,7 @@ defmodule SelectoComponents.QueryContract do
         |> Map.put(:query_contract_version, @query_contract_version)
         |> put_contract_envelope(opts)
         |> maybe_put_form_metadata(opts)
+        |> Policy.apply(opts)
         |> json_safe()
 
       {:ok, document, diagnostics}

--- a/lib/selecto_components/query_contract/guide/plug.ex
+++ b/lib/selecto_components/query_contract/guide/plug.ex
@@ -27,8 +27,8 @@ defmodule SelectoComponents.QueryContract.Guide.Plug do
   @impl Plug
   def call(conn, opts) do
     case contract_input(conn, opts) do
-      {:ok, input} ->
-        send_guide(conn, input, opts)
+      {:ok, input, resolved_opts} ->
+        send_guide(conn, input, Keyword.merge(opts, resolved_opts))
 
       {:error, status, code, message} ->
         send_error(conn, status, code, message)
@@ -38,7 +38,7 @@ defmodule SelectoComponents.QueryContract.Guide.Plug do
   defp contract_input(conn, opts) do
     case Keyword.fetch(opts, :domain) do
       {:ok, domain} ->
-        {:ok, domain}
+        {:ok, domain, []}
 
       :error ->
         opts
@@ -66,7 +66,8 @@ defmodule SelectoComponents.QueryContract.Guide.Plug do
       {:error, 500, :resolver_failed, Exception.message(exception)}
   end
 
-  defp normalize_resolver_result({:ok, input}), do: {:ok, input}
+  defp normalize_resolver_result({:ok, input}), do: {:ok, input, []}
+  defp normalize_resolver_result({:ok, input, opts}) when is_list(opts), do: {:ok, input, opts}
 
   defp normalize_resolver_result({:error, :invalid_resolver}) do
     {:error, 500, :invalid_resolver, "query guide resolver must be a one- or two-arity function"}
@@ -80,7 +81,8 @@ defmodule SelectoComponents.QueryContract.Guide.Plug do
     {:error, 404, :not_found, "query guide domain not found"}
   end
 
-  defp normalize_resolver_result(input), do: {:ok, input}
+  defp normalize_resolver_result({input, opts}) when is_list(opts), do: {:ok, input, opts}
+  defp normalize_resolver_result(input), do: {:ok, input, []}
 
   defp send_guide(conn, input, opts) do
     opts = Links.with_request_defaults(conn, opts, :query_guide)

--- a/lib/selecto_components/query_contract/intent_validator/plug.ex
+++ b/lib/selecto_components/query_contract/intent_validator/plug.ex
@@ -24,9 +24,9 @@ defmodule SelectoComponents.QueryContract.IntentValidator.Plug do
 
   @impl Plug
   def call(%Plug.Conn{method: "POST"} = conn, opts) do
-    with {:ok, input} <- contract_input(conn, opts),
+    with {:ok, input, resolved_opts} <- contract_input(conn, opts),
          {:ok, intent, conn} <- request_intent(conn) do
-      send_validation(conn, input, intent, opts)
+      send_validation(conn, input, intent, Keyword.merge(opts, resolved_opts))
     else
       {:error, status, code, message} ->
         send_error(conn, status, code, message)
@@ -42,7 +42,7 @@ defmodule SelectoComponents.QueryContract.IntentValidator.Plug do
   defp contract_input(conn, opts) do
     case Keyword.fetch(opts, :domain) do
       {:ok, domain} ->
-        {:ok, domain}
+        {:ok, domain, []}
 
       :error ->
         opts
@@ -70,7 +70,8 @@ defmodule SelectoComponents.QueryContract.IntentValidator.Plug do
       {:error, 500, :resolver_failed, Exception.message(exception)}
   end
 
-  defp normalize_resolver_result({:ok, input}), do: {:ok, input}
+  defp normalize_resolver_result({:ok, input}), do: {:ok, input, []}
+  defp normalize_resolver_result({:ok, input, opts}) when is_list(opts), do: {:ok, input, opts}
 
   defp normalize_resolver_result({:error, :invalid_resolver}) do
     {:error, 500, :invalid_resolver,
@@ -85,7 +86,8 @@ defmodule SelectoComponents.QueryContract.IntentValidator.Plug do
     {:error, 404, :not_found, "query intent validator domain not found"}
   end
 
-  defp normalize_resolver_result(input), do: {:ok, input}
+  defp normalize_resolver_result({input, opts}) when is_list(opts), do: {:ok, input, opts}
+  defp normalize_resolver_result(input), do: {:ok, input, []}
 
   defp request_intent(%Plug.Conn{body_params: %Plug.Conn.Unfetched{}} = conn) do
     read_json_intent(conn)

--- a/lib/selecto_components/query_contract/plug.ex
+++ b/lib/selecto_components/query_contract/plug.ex
@@ -27,8 +27,8 @@ defmodule SelectoComponents.QueryContract.Plug do
   @impl Plug
   def call(conn, opts) do
     case contract_input(conn, opts) do
-      {:ok, input} ->
-        send_contract(conn, input, opts)
+      {:ok, input, resolved_opts} ->
+        send_contract(conn, input, Keyword.merge(opts, resolved_opts))
 
       {:error, status, code, message} ->
         send_error(conn, status, code, message)
@@ -38,7 +38,7 @@ defmodule SelectoComponents.QueryContract.Plug do
   defp contract_input(conn, opts) do
     case Keyword.fetch(opts, :domain) do
       {:ok, domain} ->
-        {:ok, domain}
+        {:ok, domain, []}
 
       :error ->
         opts
@@ -66,7 +66,8 @@ defmodule SelectoComponents.QueryContract.Plug do
       {:error, 500, :resolver_failed, Exception.message(exception)}
   end
 
-  defp normalize_resolver_result({:ok, input}), do: {:ok, input}
+  defp normalize_resolver_result({:ok, input}), do: {:ok, input, []}
+  defp normalize_resolver_result({:ok, input, opts}) when is_list(opts), do: {:ok, input, opts}
 
   defp normalize_resolver_result({:error, :invalid_resolver}) do
     {:error, 500, :invalid_resolver,
@@ -81,7 +82,8 @@ defmodule SelectoComponents.QueryContract.Plug do
     {:error, 404, :not_found, "query contract domain not found"}
   end
 
-  defp normalize_resolver_result(input), do: {:ok, input}
+  defp normalize_resolver_result({input, opts}) when is_list(opts), do: {:ok, input, opts}
+  defp normalize_resolver_result(input), do: {:ok, input, []}
 
   defp send_contract(conn, input, opts) do
     opts = Links.with_request_defaults(conn, opts, :query_contract)

--- a/lib/selecto_components/query_contract/policy.ex
+++ b/lib/selecto_components/query_contract/policy.ex
@@ -209,25 +209,40 @@ defmodule SelectoComponents.QueryContract.Policy do
   end
 
   defp put_decision(entry, decision_entry) do
-    Map.put(entry, :capability_decision, decision_entry)
+    put_entry_value(entry, :capability_decision, decision_entry)
   end
 
   defp disable_entry(entry, :field, decision_entry) do
     entry
     |> put_decision(decision_entry)
-    |> Map.put(:disabled, true)
-    |> Map.put(:comparators, [])
-    |> Map.put(:aggregate_functions, [])
+    |> put_entry_value(:disabled, true)
+    |> put_entry_value(:comparators, [])
+    |> put_entry_value(:aggregate_functions, [])
     |> then(fn entry ->
-      Enum.reduce(@field_surface_keys, entry, &Map.put(&2, String.to_atom(&1), false))
+      Enum.reduce(@field_surface_keys, entry, &put_entry_value(&2, String.to_atom(&1), false))
     end)
   end
 
   defp disable_entry(entry, :filter, decision_entry) do
     entry
     |> put_decision(decision_entry)
-    |> Map.put(:disabled, true)
-    |> Map.put(:comparators, [])
+    |> put_entry_value(:disabled, true)
+    |> put_entry_value(:comparators, [])
+  end
+
+  defp put_entry_value(entry, key, value) when is_atom(key) do
+    string_key = Atom.to_string(key)
+
+    cond do
+      Map.has_key?(entry, key) -> Map.put(entry, key, value)
+      Map.has_key?(entry, string_key) -> Map.put(entry, string_key, value)
+      string_keyed_entry?(entry) -> Map.put(entry, string_key, value)
+      true -> Map.put(entry, key, value)
+    end
+  end
+
+  defp string_keyed_entry?(entry) do
+    Enum.any?(entry, fn {key, _value} -> is_binary(key) end)
   end
 
   defp prune_field_choice_bindings(contract, hidden_field_ids) do

--- a/lib/selecto_components/query_contract/policy.ex
+++ b/lib/selecto_components/query_contract/policy.ex
@@ -1,0 +1,334 @@
+defmodule SelectoComponents.QueryContract.Policy do
+  @moduledoc """
+  Applies host-owned capability decisions to query contract documents.
+
+  Core Selecto describes which fields and filters exist. Host applications can
+  then use this module to project actor-specific policy into that contract
+  without teaching Selecto about roles or a particular authorization engine.
+  """
+
+  @field_surface_keys ~w(detail_selectable filterable sortable groupable aggregatable)
+
+  @doc """
+  Applies a capability resolver to field and filter entries in a query contract.
+
+  Entries without a declared capability are left alone. Hidden decisions remove
+  entries from the contract. Disabled decisions keep entries visible but remove
+  the operations that would let a consumer use them.
+  """
+  @spec apply(map(), keyword()) :: map()
+  def apply(contract, opts \\ [])
+
+  def apply(contract, opts) when is_map(contract) do
+    resolver = Keyword.get(opts, :capability_resolver)
+
+    if is_function(resolver, 1) or is_function(resolver, 2) do
+      {fields, field_decisions} =
+        contract
+        |> map_value(:fields, [])
+        |> list_or_empty()
+        |> project_entries(:field, opts)
+
+      hidden_field_ids =
+        field_decisions
+        |> Enum.filter(&(map_value(&1, :status) == "hidden"))
+        |> Enum.map(&map_value(&1, :id))
+        |> MapSet.new()
+
+      {filters, filter_decisions} =
+        contract
+        |> map_value(:filters, [])
+        |> list_or_empty()
+        |> project_entries(:filter, opts)
+
+      hidden_filter_ids =
+        filter_decisions
+        |> Enum.filter(&(map_value(&1, :status) == "hidden"))
+        |> Enum.map(&map_value(&1, :id))
+        |> MapSet.new()
+
+      decisions = field_decisions ++ filter_decisions
+
+      contract
+      |> Map.put(:fields, fields)
+      |> Map.put(:filters, filters)
+      |> prune_field_choice_bindings(hidden_field_ids)
+      |> prune_defaults(hidden_field_ids, hidden_filter_ids)
+      |> put_policy_summary(decisions, opts)
+    else
+      contract
+    end
+  end
+
+  def apply(contract, _opts), do: contract
+
+  defp project_entries(entries, kind, opts) do
+    Enum.reduce(entries, {[], []}, fn entry, {projected, decisions} ->
+      capability = entry |> map_value(:capability) |> normalize_optional_id()
+
+      if is_nil(capability) do
+        {[entry | projected], decisions}
+      else
+        decision = entry_decision(entry, kind, capability, opts)
+        decision_entry = decision_entry(entry, kind, capability, decision)
+
+        case map_value(decision_entry, :status) do
+          "hidden" ->
+            {projected, [decision_entry | decisions]}
+
+          "disabled" ->
+            {[disable_entry(entry, kind, decision_entry) | projected],
+             [decision_entry | decisions]}
+
+          _enabled ->
+            {[put_decision(entry, decision_entry) | projected], [decision_entry | decisions]}
+        end
+      end
+    end)
+    |> then(fn {projected, decisions} ->
+      {Enum.reverse(projected), Enum.reverse(decisions)}
+    end)
+  end
+
+  defp entry_decision(entry, kind, capability, opts) do
+    request =
+      Selecto.Capabilities.request(
+        actor: Keyword.get(opts, :actor),
+        tenant: Keyword.get(opts, :tenant),
+        domain: Keyword.get(opts, :domain),
+        capability: capability,
+        operation: operation_for(kind, entry),
+        target: target_for(entry, kind),
+        context:
+          opts
+          |> Keyword.get(:context, %{})
+          |> map_or_empty()
+          |> Map.merge(%{
+            surface: Keyword.get(opts, :surface, :query_contract),
+            kind: kind,
+            id: entry |> map_value(:id) |> normalize_id()
+          }),
+        metadata:
+          opts
+          |> Keyword.get(:metadata, %{})
+          |> map_or_empty()
+      )
+
+    case Keyword.get(opts, :capability_resolver) do
+      resolver when is_function(resolver, 1) ->
+        resolver.(request)
+
+      resolver when is_function(resolver, 2) ->
+        resolver.(request, Keyword.get(opts, :resolver_context, %{}))
+    end
+    |> unwrap_decision()
+    |> normalize_decision()
+  end
+
+  defp operation_for(:field, entry) do
+    cond do
+      truthy?(map_value(entry, :aggregatable)) -> :query_aggregate_field
+      truthy?(map_value(entry, :groupable)) -> :query_group_field
+      truthy?(map_value(entry, :filterable)) -> :query_filter_field
+      true -> :query_select_field
+    end
+  end
+
+  defp operation_for(:filter, _entry), do: :query_filter
+
+  defp target_for(entry, kind) do
+    %{
+      kind: kind,
+      id: entry |> map_value(:id) |> normalize_id(),
+      field: entry |> map_value(:field) |> normalize_optional_id(),
+      capability: entry |> map_value(:capability) |> normalize_optional_id()
+    }
+  end
+
+  defp unwrap_decision({:ok, decision}), do: decision
+  defp unwrap_decision({:error, reason}), do: %{status: :disabled, reason: inspect(reason)}
+  defp unwrap_decision(decision), do: decision
+
+  defp normalize_decision(%Selecto.Capabilities.Decision{} = decision) do
+    %{
+      "status" => decision_status(decision),
+      "reason" => decision.user_message,
+      "code" => decision.reason_code,
+      "metadata" => decision.metadata
+    }
+    |> compact_map()
+  end
+
+  defp normalize_decision(%{} = decision) do
+    status =
+      decision
+      |> map_value(:status, map_value(decision, :visibility, "enabled"))
+      |> normalize_status()
+
+    %{
+      "status" => status,
+      "reason" => map_value(decision, :reason) || map_value(decision, :user_message),
+      "code" => map_value(decision, :code) || map_value(decision, :reason_code),
+      "metadata" => map_value(decision, :metadata)
+    }
+    |> compact_map()
+  end
+
+  defp normalize_decision(true), do: %{"status" => "enabled"}
+  defp normalize_decision(false), do: %{"status" => "disabled"}
+  defp normalize_decision(:allow), do: %{"status" => "enabled"}
+  defp normalize_decision(:deny), do: %{"status" => "disabled"}
+  defp normalize_decision(:hidden), do: %{"status" => "hidden"}
+  defp normalize_decision(nil), do: %{"status" => "enabled"}
+  defp normalize_decision(_decision), do: %{"status" => "disabled"}
+
+  defp decision_status(%Selecto.Capabilities.Decision{status: :allow}), do: "enabled"
+  defp decision_status(%Selecto.Capabilities.Decision{visibility: :hidden}), do: "hidden"
+  defp decision_status(%Selecto.Capabilities.Decision{status: :not_applicable}), do: "hidden"
+  defp decision_status(%Selecto.Capabilities.Decision{}), do: "disabled"
+
+  defp normalize_status(status) when status in [:enabled, :allow], do: "enabled"
+  defp normalize_status(status) when status in [:disabled, :deny], do: "disabled"
+  defp normalize_status(status) when status in [:hidden, :not_applicable], do: "hidden"
+  defp normalize_status("allow"), do: "enabled"
+  defp normalize_status("deny"), do: "disabled"
+  defp normalize_status("not_applicable"), do: "hidden"
+  defp normalize_status(status) when status in ["enabled", "disabled", "hidden"], do: status
+  defp normalize_status(_status), do: "enabled"
+
+  defp decision_entry(entry, kind, capability, decision) do
+    %{
+      "kind" => Atom.to_string(kind),
+      "id" => entry |> map_value(:id) |> normalize_id(),
+      "capability" => capability,
+      "status" => map_value(decision, :status, "enabled"),
+      "reason" => map_value(decision, :reason),
+      "code" => map_value(decision, :code)
+    }
+    |> compact_map()
+  end
+
+  defp put_decision(entry, decision_entry) do
+    Map.put(entry, :capability_decision, decision_entry)
+  end
+
+  defp disable_entry(entry, :field, decision_entry) do
+    entry
+    |> put_decision(decision_entry)
+    |> Map.put(:disabled, true)
+    |> Map.put(:comparators, [])
+    |> Map.put(:aggregate_functions, [])
+    |> then(fn entry ->
+      Enum.reduce(@field_surface_keys, entry, &Map.put(&2, String.to_atom(&1), false))
+    end)
+  end
+
+  defp disable_entry(entry, :filter, decision_entry) do
+    entry
+    |> put_decision(decision_entry)
+    |> Map.put(:disabled, true)
+    |> Map.put(:comparators, [])
+  end
+
+  defp prune_field_choice_bindings(contract, hidden_field_ids) do
+    Map.update(contract, :field_choice_bindings, [], fn bindings ->
+      bindings
+      |> list_or_empty()
+      |> Enum.reject(fn binding ->
+        hidden_field_ids |> MapSet.member?(binding |> map_value(:field) |> normalize_id())
+      end)
+    end)
+  end
+
+  defp prune_defaults(contract, hidden_field_ids, hidden_filter_ids) do
+    Map.update(contract, :defaults, %{}, fn defaults ->
+      defaults
+      |> map_or_empty()
+      |> Map.update(:default_selected, [], &reject_ids(&1, hidden_field_ids))
+      |> Map.update(:required_selected, [], &reject_ids(&1, hidden_field_ids))
+      |> Map.update(:required_group_by, [], &reject_ids(&1, hidden_field_ids))
+      |> Map.update(:required_order_by, [], &reject_order_by(&1, hidden_field_ids))
+      |> Map.update(:required_filters, [], &reject_filters(&1, hidden_filter_ids))
+    end)
+  end
+
+  defp reject_ids(values, hidden_ids) do
+    values
+    |> list_or_empty()
+    |> Enum.reject(&MapSet.member?(hidden_ids, normalize_id(&1)))
+  end
+
+  defp reject_order_by(values, hidden_ids) do
+    values
+    |> list_or_empty()
+    |> Enum.reject(fn
+      {field, _dir} -> MapSet.member?(hidden_ids, normalize_id(field))
+      %{} = item -> MapSet.member?(hidden_ids, item |> map_value(:field) |> normalize_id())
+      field -> MapSet.member?(hidden_ids, normalize_id(field))
+    end)
+  end
+
+  defp reject_filters(values, hidden_ids) do
+    values
+    |> list_or_empty()
+    |> Enum.reject(fn
+      %{} = item -> MapSet.member?(hidden_ids, item |> map_value(:filter) |> normalize_id())
+      filter -> MapSet.member?(hidden_ids, normalize_id(filter))
+    end)
+  end
+
+  defp put_policy_summary(contract, decisions, opts) do
+    summary = %{
+      applied: true,
+      resolver: resolver_name(Keyword.get(opts, :capability_resolver)),
+      decisions: decisions,
+      counts:
+        Enum.reduce(decisions, %{"enabled" => 0, "disabled" => 0, "hidden" => 0}, fn decision,
+                                                                                     counts ->
+          Map.update(counts, map_value(decision, :status, "enabled"), 1, &(&1 + 1))
+        end)
+    }
+
+    Map.put(contract, :capability_policy, summary)
+  end
+
+  defp resolver_name({module, function}) when is_atom(module) and is_atom(function),
+    do: "#{inspect(module)}.#{function}/2"
+
+  defp resolver_name(fun) when is_function(fun),
+    do: "function/#{:erlang.fun_info(fun, :arity) |> elem(1)}"
+
+  defp resolver_name(_resolver), do: nil
+
+  defp map_value(map, key, default \\ nil)
+
+  defp map_value(map, key, default) when is_map(map) and is_atom(key) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
+
+  defp map_value(map, key, default) when is_map(map), do: Map.get(map, key, default)
+  defp map_value(_map, _key, default), do: default
+
+  defp map_or_empty(value) when is_map(value), do: value
+  defp map_or_empty(_value), do: %{}
+
+  defp list_or_empty(value) when is_list(value), do: value
+  defp list_or_empty(_value), do: []
+
+  defp normalize_optional_id(nil), do: nil
+  defp normalize_optional_id(""), do: nil
+  defp normalize_optional_id(value), do: normalize_id(value)
+
+  defp normalize_id(value) when is_binary(value), do: value
+  defp normalize_id(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_id(value), do: to_string(value)
+
+  defp truthy?(value) when value in [true, "true", 1, "1"], do: true
+  defp truthy?(_value), do: false
+
+  defp compact_map(map) do
+    map
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == %{} or value == [] end)
+    |> Map.new()
+  end
+end

--- a/lib/selecto_components/views/detail/form.ex
+++ b/lib/selecto_components/views/detail/form.ex
@@ -57,7 +57,11 @@ defmodule SelectoComponents.Views.Detail.Form do
       )
       |> normalize_checkbox_value()
 
-    row_action_options = RowActions.available_actions(assigns.selecto)
+    row_action_options =
+      RowActions.available_actions(
+        assigns.selecto,
+        Map.get(assigns, :row_action_availability_opts, [])
+      )
 
     selected_row_action =
       Enum.find(row_action_options, fn action -> action.id == row_click_action end)

--- a/lib/selecto_components/views/detail/row_actions.ex
+++ b/lib/selecto_components/views/detail/row_actions.ex
@@ -10,8 +10,8 @@ defmodule SelectoComponents.Views.Detail.RowActions do
   def default_modal_action_id, do: @default_modal_action_id
   def generated_action_form_prefix, do: @generated_action_form_prefix
 
-  def available_actions(selecto) do
-    [default_modal_action() | registered_actions(selecto)]
+  def available_actions(selecto, opts \\ []) do
+    [default_modal_action() | registered_actions(selecto, opts)]
   end
 
   def current_action(selecto, row_click_action, opts \\ []) do
@@ -29,7 +29,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
         Map.put(default_modal_action(), :source, :configured)
 
       true ->
-        registered_actions(selecto)
+        registered_actions(selecto, opts)
         |> Enum.find(fn action -> action.id == action_id end)
         |> case do
           nil -> nil
@@ -166,12 +166,12 @@ defmodule SelectoComponents.Views.Detail.RowActions do
 
   def resolve_component_assigns(_assigns_template, _source), do: %{}
 
-  defp registered_actions(selecto) do
+  defp registered_actions(selecto, opts) do
     domain = Selecto.domain(selecto)
 
     domain
     |> registered_detail_actions()
-    |> Kernel.++(generated_action_forms(domain))
+    |> Kernel.++(generated_action_forms(domain, opts))
     |> Enum.map(&normalize_action/1)
     |> Enum.reject(&is_nil/1)
     |> Enum.sort_by(&String.downcase(&1.name))
@@ -185,12 +185,17 @@ defmodule SelectoComponents.Views.Detail.RowActions do
 
   defp registered_detail_actions(_domain), do: %{}
 
-  defp generated_action_forms(domain) when is_map(domain) do
+  defp generated_action_forms(domain, opts) when is_map(domain) do
     domain
     |> Actions.detail_actions(
-      id_prefix: @generated_action_form_prefix,
-      required_fields: [:id],
-      target: %{id: {:field, "id"}}
+      Keyword.merge(
+        [
+          id_prefix: @generated_action_form_prefix,
+          required_fields: [:id],
+          target: %{id: {:field, "id"}}
+        ],
+        opts
+      )
     )
     |> Enum.map(fn {id, config} -> {id, Map.put(config, :source, :generated_action_form)} end)
     |> Enum.filter(fn {_id, config} ->
@@ -203,7 +208,7 @@ defmodule SelectoComponents.Views.Detail.RowActions do
     end)
   end
 
-  defp generated_action_forms(_domain), do: []
+  defp generated_action_forms(_domain, _opts), do: []
 
   defp normalize_action({action_id, action_config}) when is_map(action_config) do
     type = normalize_action_type(map_get(action_config, :type))

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -90,6 +90,56 @@ defmodule SelectoComponents.ActionsTest do
     assert action.reason == "Approval window is closed"
   end
 
+  test "uses host capability resolver decisions for action availability" do
+    resolver = fn request ->
+      assert %Selecto.Capabilities.Request{} = request
+      assert request.capability == "orders.approve"
+      assert request.operation == "update"
+      assert request.context.surface == :components
+      assert request.context.action_id == "approve_order"
+
+      Selecto.Capabilities.deny(:missing_role, user_message: "Managers only")
+    end
+
+    assert [action] =
+             Actions.available(write_contract(),
+               actor: %{id: 1, role: :analyst},
+               domain: :orders,
+               capability_resolver: resolver
+             )
+
+    assert action.id == "approve_order"
+    assert action.status == "disabled"
+    assert action.disabled? == true
+    assert action.reason == "Managers only"
+  end
+
+  test "filters resolver-hidden actions" do
+    actions =
+      Actions.available(write_contract(),
+        capability_resolver: fn _request ->
+          Selecto.Capabilities.hidden(:not_visible, user_message: "Not visible here")
+        end
+      )
+
+    assert actions == []
+  end
+
+  test "keeps target disabled decisions when host policy allows the action" do
+    assert [action] =
+             Actions.available(write_contract(),
+               decisions: %{
+                 "approve_order" => %{status: :disabled, reason: "Target is already closed"}
+               },
+               capability_resolver: fn _request ->
+                 Selecto.Capabilities.allow(:role_allowed, user_message: "Allowed by role")
+               end
+             )
+
+    assert action.status == "disabled"
+    assert action.reason == "Target is already closed"
+  end
+
   test "filters hidden actions and can scope visible actions" do
     contract =
       write_contract(%{

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -67,6 +67,8 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert html =~ ~r/name="confirmed"[\s\S]*disabled/
     assert html =~ ~r/value="preview"[\s\S]*disabled/
     assert html =~ ~r/value="apply"[\s\S]*disabled/
+    assert html =~ ~r/value="preview"[\s\S]*bg-slate-100[\s\S]*disabled/
+    assert html =~ ~r/value="apply"[\s\S]*bg-slate-100[\s\S]*disabled/
   end
 
   test "render exposes stable action metadata and submit hooks" do

--- a/test/selecto_components/query_contract/policy_test.exs
+++ b/test/selecto_components/query_contract/policy_test.exs
@@ -1,0 +1,126 @@
+defmodule SelectoComponents.QueryContract.PolicyTest do
+  use ExUnit.Case, async: true
+
+  alias SelectoComponents.QueryContract.Policy
+
+  test "keeps allowed fields and disables denied fields" do
+    contract = contract()
+
+    projected =
+      Policy.apply(contract,
+        actor: %{role: :analyst},
+        capability_resolver: fn request ->
+          case request.capability do
+            "items.private_metric" ->
+              Selecto.Capabilities.deny(:analyst_blocked,
+                user_message: "Analysts cannot use private metrics."
+              )
+
+            _capability ->
+              Selecto.Capabilities.allow()
+          end
+        end
+      )
+
+    assert field(projected, "name").detail_selectable == true
+
+    assert %{
+             detail_selectable: false,
+             filterable: false,
+             sortable: false,
+             groupable: false,
+             aggregatable: false,
+             comparators: [],
+             aggregate_functions: [],
+             disabled: true,
+             capability_decision: %{
+               "status" => "disabled",
+               "code" => :analyst_blocked,
+               "reason" => "Analysts cannot use private metrics."
+             }
+           } = field(projected, "private_metric")
+
+    assert projected.capability_policy.counts == %{
+             "enabled" => 3,
+             "disabled" => 1,
+             "hidden" => 0
+           }
+  end
+
+  test "removes hidden fields, filters, bindings, and defaults" do
+    contract = contract()
+
+    projected =
+      Policy.apply(contract,
+        capability_resolver: fn request ->
+          case request.capability do
+            "items.private_metric" -> Selecto.Capabilities.hidden(:not_visible)
+            "items.private_filter" -> Selecto.Capabilities.hidden(:not_visible)
+            _capability -> Selecto.Capabilities.allow()
+          end
+        end
+      )
+
+    refute field(projected, "private_metric")
+    refute Enum.any?(projected.filters, &(&1.id == "private_filter"))
+    refute Enum.any?(projected.field_choice_bindings, &(&1.field == "private_metric"))
+    refute "private_metric" in projected.defaults.default_selected
+    refute "private_filter" in projected.defaults.required_filters
+
+    assert projected.capability_policy.counts == %{
+             "enabled" => 2,
+             "disabled" => 0,
+             "hidden" => 2
+           }
+  end
+
+  defp field(contract, id), do: Enum.find(contract.fields, &(&1.id == id))
+
+  defp contract do
+    %{
+      fields: [
+        %{
+          id: "name",
+          capability: "items.read",
+          detail_selectable: true,
+          filterable: true,
+          sortable: true,
+          groupable: true,
+          aggregatable: false,
+          comparators: ["eq", "contains"],
+          aggregate_functions: []
+        },
+        %{
+          id: "private_metric",
+          capability: "items.private_metric",
+          detail_selectable: true,
+          filterable: true,
+          sortable: true,
+          groupable: true,
+          aggregatable: true,
+          comparators: ["eq", "gt"],
+          aggregate_functions: ["sum"]
+        }
+      ],
+      filters: [
+        %{id: "name", field: "name", capability: "items.read", comparators: ["eq"]},
+        %{
+          id: "private_filter",
+          field: "private_metric",
+          capability: "items.private_filter",
+          comparators: ["eq"]
+        }
+      ],
+      field_choice_bindings: [
+        %{field: "private_metric", choice_source: "private_choices"}
+      ],
+      defaults: %{
+        default_selected: ["name", "private_metric"],
+        required_selected: ["private_metric"],
+        required_group_by: ["private_metric"],
+        required_order_by: [%{field: "private_metric", dir: "asc"}],
+        required_filters: ["private_filter"]
+      }
+    }
+  end
+end

--- a/test/selecto_components/query_contract/policy_test.exs
+++ b/test/selecto_components/query_contract/policy_test.exs
@@ -47,6 +47,33 @@ defmodule SelectoComponents.QueryContract.PolicyTest do
            }
   end
 
+  test "disables string-keyed field and filter surfaces" do
+    projected =
+      Policy.apply(string_keyed_contract(),
+        capability_resolver: fn _request ->
+          Selecto.Capabilities.deny(:blocked, user_message: "Blocked")
+        end
+      )
+
+    assert %{
+             "detail_selectable" => false,
+             "filterable" => false,
+             "sortable" => false,
+             "groupable" => false,
+             "aggregatable" => false,
+             "comparators" => [],
+             "aggregate_functions" => [],
+             "disabled" => true,
+             "capability_decision" => %{"status" => "disabled"}
+           } = field(projected, "private_metric")
+
+    assert %{
+             "comparators" => [],
+             "disabled" => true,
+             "capability_decision" => %{"status" => "disabled"}
+           } = Enum.find(projected.filters, &(&1["id"] == "private_filter"))
+  end
+
   test "removes hidden fields, filters, bindings, and defaults" do
     contract = contract()
 
@@ -74,7 +101,8 @@ defmodule SelectoComponents.QueryContract.PolicyTest do
            }
   end
 
-  defp field(contract, id), do: Enum.find(contract.fields, &(&1.id == id))
+  defp field(contract, id),
+    do: Enum.find(contract.fields, &(Map.get(&1, :id, Map.get(&1, "id")) == id))
 
   defp contract do
     %{
@@ -121,6 +149,32 @@ defmodule SelectoComponents.QueryContract.PolicyTest do
         required_order_by: [%{field: "private_metric", dir: "asc"}],
         required_filters: ["private_filter"]
       }
+    }
+  end
+
+  defp string_keyed_contract do
+    %{
+      fields: [
+        %{
+          "id" => "private_metric",
+          "capability" => "items.private_metric",
+          "detail_selectable" => true,
+          "filterable" => true,
+          "sortable" => true,
+          "groupable" => true,
+          "aggregatable" => true,
+          "comparators" => ["eq", "gt"],
+          "aggregate_functions" => ["sum"]
+        }
+      ],
+      filters: [
+        %{
+          "id" => "private_filter",
+          "field" => "private_metric",
+          "capability" => "items.private_filter",
+          "comparators" => ["eq"]
+        }
+      ]
     }
   end
 end

--- a/test/selecto_components/views/detail/form_test.exs
+++ b/test/selecto_components/views/detail/form_test.exs
@@ -118,6 +118,72 @@ defmodule SelectoComponents.Views.Detail.FormTest do
     assert html =~ "apply: /work-items/actions/archive/apply"
   end
 
+  test "filters generated row action form choices through capability resolver" do
+    domain = %{
+      name: "DetailFormPolicyActionsTest",
+      source: %{
+        source_table: "work_items",
+        primary_key: :id,
+        fields: [:id, :title],
+        redact_fields: [],
+        columns: %{
+          id: %{type: :integer, name: "ID", colid: :id},
+          title: %{type: :string, name: "Title", colid: :title}
+        },
+        associations: %{}
+      },
+      schemas: %{},
+      joins: %{},
+      detail_actions: %{},
+      actions: %{
+        archive: %{
+          id: :archive,
+          label: "Archive",
+          scope: :row,
+          capability: "work_items.archive",
+          execution: %{operation: :update}
+        },
+        set_estimate: %{
+          id: :set_estimate,
+          label: "Set estimate",
+          scope: :row,
+          capability: "work_items.estimation",
+          execution: %{operation: :update}
+        }
+      }
+    }
+
+    html =
+      render_component(Form, %{
+        id: "detail-form-policy-actions-test",
+        columns: [{:id, "ID", :integer}, {:title, "Title", :string}],
+        view: {:detail, SelectoComponents.Views.Detail, "Detail", %{}},
+        selecto: Selecto.configure(domain, nil),
+        row_action_availability_opts: [
+          capability_resolver: fn
+            %{capability: "work_items.archive"} ->
+              Selecto.Capabilities.hidden(:not_visible)
+
+            _request ->
+              Selecto.Capabilities.allow(:allowed)
+          end
+        ],
+        view_config: %{
+          views: %{
+            detail: %{
+              selected: [],
+              order_by: [],
+              row_click_action: ""
+            }
+          }
+        }
+      })
+
+    refute html =~ ~s(value="domain_action_form_archive")
+    assert html =~ ~s(value="domain_action_form_set_estimate")
+    assert html =~ "Set estimate"
+  end
+
   test "uses detail config as the only row click action source while editing" do
     domain = %{
       name: "DetailFormParamsTest",


### PR DESCRIPTION
## Summary
- Projects host capability decisions into query contract fields and filters.
- Adds disabled and hidden policy semantics, including capability_decision metadata and capability_policy counts.
- Allows query contract, guide, and intent-validator resolvers to return request-scoped options alongside the domain.

## Validation
- SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix test
- SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix format --check-formatted
- git diff --check