### PR TITLE
Harden action form submit payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,17 @@ LiveView:
 %{
   intent: "apply",
   action_id: "set_estimate",
+  action_label: "Set estimate",
+  action_scope: "row",
+  action_operation: "update",
+  capability: "work_items.estimation",
+  target: %{"id" => 42},
+  inputs: %{"estimate_hours" => "8"},
+  confirmation_required?: false,
+  endpoints: %{
+    "preview" => %{"href" => "/api/v1/updato/work-items/actions/set_estimate/preview"},
+    "apply" => %{"href" => "/api/v1/updato/work-items/actions/set_estimate/apply"}
+  },
   request: %{
     "action" => "set_estimate",
     "target" => %{"id" => 42},

--- a/docs/developer_integration_guide.md
+++ b/docs/developer_integration_guide.md
@@ -137,6 +137,17 @@ The modal sends:
 %{
   intent: "preview" | "apply",
   action_id: "approve",
+  action_label: "Approve",
+  action_scope: "row",
+  action_operation: "update",
+  capability: "orders.approve",
+  target: %{"id" => 42},
+  inputs: %{"note" => "Ready"},
+  confirmation_required?: true,
+  endpoints: %{
+    "preview" => %{"href" => "/api/selecto/orders/actions/approve/preview"},
+    "apply" => %{"href" => "/api/selecto/orders/actions/approve/apply"}
+  },
   request: %{
     "action" => "approve",
     "target" => %{"id" => 42},
@@ -166,6 +177,9 @@ Host callbacks should be deterministic and side-effect aware:
 - `authorize` runs before preview or apply.
 - `preview` must not mutate data.
 - `apply` owns the write.
+- `preview` and `apply` can use arity 4
+  `(action_id, request, socket, payload)` when they need normalized action
+  metadata, endpoints, target, or inputs from the submit payload.
 - `after_apply` owns reload behavior and final result shape.
 - `format_error` maps host errors to clear messages.
 

--- a/lib/selecto_components/action_form_host.ex
+++ b/lib/selecto_components/action_form_host.ex
@@ -31,21 +31,31 @@ defmodule SelectoComponents.ActionFormHost do
   - `:format_error` - callback invoked as `(reason)` for host-specific error messages
   """
   def handle_submit(socket, payload, opts) when is_map(payload) do
-    action_id = Map.fetch!(payload, :action_id)
-    request = Map.fetch!(payload, :request)
-    intent = payload |> Map.get(:intent) |> normalize_intent()
+    with {:ok, payload} <- normalize_submit_payload(payload) do
+      action_id = Map.fetch!(payload, :action_id)
+      request = Map.fetch!(payload, :request)
+      intent = payload |> Map.get(:intent) |> normalize_intent()
 
-    with :ok <- authorize_action(action_id, request, socket, intent, opts),
-         {:ok, result} <-
-           opts
-           |> Keyword.fetch!(intent)
-           |> call_action(action_id, request, socket) do
-      {socket, metadata} = maybe_after_apply(socket, intent, result, opts)
-      {:noreply, assign_result(socket, Atom.to_string(intent), result, metadata)}
+      with :ok <- authorize_action(action_id, request, socket, intent, opts),
+           {:ok, result} <-
+             opts
+             |> Keyword.fetch!(intent)
+             |> call_action(action_id, request, socket, payload) do
+        {socket, metadata} = maybe_after_apply(socket, intent, result, opts)
+        {:noreply, assign_result(socket, Atom.to_string(intent), result, metadata)}
+      else
+        {:error, reason} ->
+          {:noreply, assign_error(socket, error_message(reason, opts), reason)}
+      end
     else
       {:error, reason} ->
         {:noreply, assign_error(socket, error_message(reason, opts), reason)}
     end
+  end
+
+  def handle_submit(socket, _payload, opts) do
+    reason = {:invalid_action_form_payload, "expected action form payload map", %{}}
+    {:noreply, assign_error(socket, error_message(reason, opts), reason)}
   end
 
   def assign_result(socket, intent, result, metadata \\ %{}) do
@@ -91,10 +101,39 @@ defmodule SelectoComponents.ActionFormHost do
     end
   end
 
-  defp call_action(callback, action_id, request, socket) when is_function(callback, 3),
+  defp normalize_submit_payload(payload) do
+    action_id = Map.get(payload, :action_id, Map.get(payload, "action_id"))
+    request = Map.get(payload, :request, Map.get(payload, "request"))
+    intent = Map.get(payload, :intent, Map.get(payload, "intent"))
+
+    cond do
+      not is_binary(action_id) or action_id == "" ->
+        {:error,
+         {:invalid_action_form_payload, "action form payload is missing action_id",
+          %{field: :action_id}}}
+
+      not is_map(request) ->
+        {:error,
+         {:invalid_action_form_payload, "action form payload is missing request",
+          %{field: :request}}}
+
+      true ->
+        {:ok,
+         payload
+         |> QueryContract.json_safe()
+         |> Map.put(:action_id, action_id)
+         |> Map.put(:request, request)
+         |> Map.put(:intent, intent)}
+    end
+  end
+
+  defp call_action(callback, action_id, request, socket, payload) when is_function(callback, 4),
+    do: callback.(action_id, request, socket, payload)
+
+  defp call_action(callback, action_id, request, socket, _payload) when is_function(callback, 3),
     do: callback.(action_id, request, socket)
 
-  defp call_action(callback, action_id, request, _socket) when is_function(callback, 2),
+  defp call_action(callback, action_id, request, _socket, _payload) when is_function(callback, 2),
     do: callback.(action_id, request)
 
   defp authorize_action(action_id, request, socket, intent, opts) do
@@ -150,6 +189,7 @@ defmodule SelectoComponents.ActionFormHost do
   defp default_error_message({:validation_error, message, _details}), do: message
   defp default_error_message({:capability_denied, message, _details}), do: message
   defp default_error_message({:invalid_request, message}), do: message
+  defp default_error_message({:invalid_action_form_payload, message, _details}), do: message
   defp default_error_message(:capability_denied), do: "Action is not allowed."
   defp default_error_message(reason) when is_binary(reason), do: reason
   defp default_error_message(reason), do: inspect(reason)
@@ -172,6 +212,14 @@ defmodule SelectoComponents.ActionFormHost do
 
   defp error_details({:invalid_request, message}) do
     %{"type" => "invalid_request", "message" => message}
+  end
+
+  defp error_details({:invalid_action_form_payload, message, details}) do
+    details
+    |> QueryContract.json_safe()
+    |> map_or_empty()
+    |> Map.put_new("message", message)
+    |> Map.put_new("type", "invalid_action_form_payload")
   end
 
   defp error_details(:capability_denied) do

--- a/lib/selecto_components/modal/action_form_modal.ex
+++ b/lib/selecto_components/modal/action_form_modal.ex
@@ -336,11 +336,7 @@ defmodule SelectoComponents.Modal.ActionFormModal do
         confirmed: confirmed
       )
 
-    payload = %{
-      intent: intent,
-      action_id: Map.get(action, "id"),
-      request: request
-    }
+    payload = action_submit_payload(action, target, intent, inputs, request)
 
     send(self(), {:selecto_action_form_submit, payload})
 
@@ -352,6 +348,26 @@ defmodule SelectoComponents.Modal.ActionFormModal do
        last_request: request,
        last_error: nil
      )}
+  end
+
+  defp action_submit_payload(action, target, intent, inputs, request) do
+    %{
+      intent: intent,
+      action_id: Map.get(action, "id"),
+      action: action,
+      action_label: Map.get(action, "label"),
+      action_scope: Map.get(action, "scope"),
+      action_operation: Map.get(action, "operation"),
+      capability: Map.get(action, "capability"),
+      endpoints: map_or_empty(Map.get(action, "endpoints")),
+      links: map_or_empty(Map.get(action, "links")),
+      target: target,
+      inputs: inputs,
+      confirmation_required?: truthy?(get_in(action, ["confirmation", "required"])),
+      request: request
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == %{} end)
+    |> Map.new()
   end
 
   defp normalize_action(action) when is_map(action),

--- a/test/selecto_components/action_form_host_test.exs
+++ b/test/selecto_components/action_form_host_test.exs
@@ -86,6 +86,65 @@ defmodule SelectoComponents.ActionFormHostTest do
              "apply"
   end
 
+  test "handle_submit accepts string-keyed payloads" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(socket(), string_payload("preview"),
+               preview: fn action_id, request, _socket ->
+                 assert action_id == "archive"
+                 assert request == %{"action" => "archive", "target" => %{"id" => 42}}
+                 {:ok, %{action: action_id}}
+               end,
+               apply: fn _action_id, _request, _socket -> {:ok, %{}} end
+             )
+
+    assert updated_socket.assigns.modal_detail_data.component_assigns.last_result["intent"] ==
+             "preview"
+  end
+
+  test "handle_submit can pass normalized submit metadata to action callbacks" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(socket(), payload("preview"),
+               preview: fn action_id, request, _socket, payload ->
+                 assert action_id == "archive"
+                 assert request["target"] == %{"id" => 42}
+                 assert payload.action_id == "archive"
+                 assert payload.intent == "preview"
+
+                 {:ok,
+                  %{
+                    action: action_id,
+                    target: payload["target"],
+                    endpoint: get_in(payload, ["endpoints", "preview", "href"])
+                  }}
+               end,
+               apply: fn _action_id, _request, _socket -> {:ok, %{}} end
+             )
+
+    result = updated_socket.assigns.modal_detail_data.component_assigns.last_result
+    assert result["payload"]["target"] == %{"id" => 42}
+    assert result["payload"]["endpoint"] == "/actions/archive/preview"
+  end
+
+  test "handle_submit reports malformed submit payloads without raising" do
+    assert {:noreply, updated_socket} =
+             ActionFormHost.handle_submit(socket(), %{"intent" => "preview"},
+               preview: fn _action_id, _request, _socket ->
+                 flunk("preview callback should not run")
+               end,
+               apply: fn _action_id, _request, _socket -> {:ok, %{}} end
+             )
+
+    component_assigns = updated_socket.assigns.modal_detail_data.component_assigns
+
+    assert component_assigns.last_error == "action form payload is missing action_id"
+
+    assert component_assigns.last_error_details == %{
+             "field" => "action_id",
+             "message" => "action form payload is missing action_id",
+             "type" => "invalid_action_form_payload"
+           }
+  end
+
   test "handle_submit preserves machine-readable error details for the component" do
     socket = socket()
 
@@ -176,7 +235,20 @@ defmodule SelectoComponents.ActionFormHostTest do
     %{
       intent: intent,
       action_id: "archive",
-      request: %{"action" => "archive", "target" => %{"id" => 42}}
+      request: %{"action" => "archive", "target" => %{"id" => 42}},
+      target: %{"id" => 42},
+      endpoints: %{
+        "preview" => %{"href" => "/actions/archive/preview"},
+        "apply" => %{"href" => "/actions/archive/apply"}
+      }
+    }
+  end
+
+  defp string_payload(intent) do
+    %{
+      "intent" => intent,
+      "action_id" => "archive",
+      "request" => %{"action" => "archive", "target" => %{"id" => 42}}
     }
   end
 end

--- a/test/selecto_components/modal/action_form_modal_test.exs
+++ b/test/selecto_components/modal/action_form_modal_test.exs
@@ -21,7 +21,19 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
     assert_receive {:selecto_action_form_submit, payload}
     assert payload.intent == "preview"
     assert payload.action_id == "archive"
-    assert Map.keys(payload) |> Enum.sort() == [:action_id, :intent, :request]
+    assert payload.action_label == "Archive"
+    assert payload.action_scope == "row"
+    assert payload.action_operation == "update"
+    assert payload.confirmation_required? == true
+    assert payload.target == %{"id" => 42}
+    assert payload.inputs == %{"note" => "Ready"}
+
+    assert payload.endpoints == %{
+             "preview" => %{"href" => "/actions/archive/preview", "method" => "POST"},
+             "apply" => %{"href" => "/actions/archive/apply", "method" => "POST"}
+           }
+
+    assert payload.action["id"] == "archive"
 
     assert payload.request == %{
              "action" => "archive",
@@ -42,9 +54,28 @@ defmodule SelectoComponents.Modal.ActionFormModalTest do
 
     assert_receive {:selecto_action_form_submit, payload}
     assert payload.intent == "apply"
-    assert Map.keys(payload) |> Enum.sort() == [:action_id, :intent, :request]
     assert payload.request["confirmed"] == true
     assert payload.request["dry_run"] == false
+    assert payload.confirmation_required? == true
+    assert payload.target == %{"id" => 42}
+  end
+
+  test "submit_action_form includes capability and link metadata when present" do
+    action =
+      action()
+      |> Map.put("capability", "work_items.archive")
+      |> Map.put("links", %{"audit" => %{"href" => "/actions/archive/audit"}})
+
+    assert {:noreply, _socket} =
+             ActionFormModal.handle_event(
+               "submit_action_form",
+               %{"intent" => "preview", "inputs" => %{"note" => "Ready"}},
+               socket(action, %{id: 42})
+             )
+
+    assert_receive {:selecto_action_form_submit, payload}
+    assert payload.capability == "work_items.archive"
+    assert payload.links == %{"audit" => %{"href" => "/actions/archive/audit"}}
   end
 
   test "render disables further submissions after apply succeeds" do


### PR DESCRIPTION
## Summary
- Expands ActionFormModal submit events with normalized action metadata, endpoints, target, inputs, and confirmation requirement.
- Hardens ActionFormHost against malformed or string-keyed submit payloads instead of raising.
- Allows preview/apply callbacks to opt into arity 4 and receive the normalized submit payload.
- Documents the richer generated action-form payload contract.

## Validation
- SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix test: 4 properties, 780 tests, 0 failures
- SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix test test/selecto_components/action_form_host_test.exs test/selecto_components/modal/action_form_modal_test.exs: 42 tests, 0 failures
- SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix test test/selecto_example_web/live/work_item_live_test.exs test/selecto_example_web/live/camp_registration_live_test.exs: 25 tests, 0 failures
- SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix format --check-formatted
- git diff --check