### PR TITLE
Merge seeken main into selecto_components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ CHANGES
 V NEXT
 --------
 
+V 0.4.9
+--------
+
 - Added `mix selecto_components.verify` with bounded-exhaustive verification of
   action-visibility monotonicity.
 - Fixed decision merging so a resolver cannot downgrade an explicitly hidden
   action to disabled and make it visible.
 - Updated the core Selecto lower bound to `0.4.8` for the shared bounded model
   checker.
+- Bump package version to `0.4.9`.
 
 V 0.4.8
 --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 CHANGES
 =======
 
+V NEXT
+--------
+
+- Added `mix selecto_components.verify` with bounded-exhaustive verification of
+  action-visibility monotonicity.
+- Fixed decision merging so a resolver cannot downgrade an explicitly hidden
+  action to disabled and make it visible.
+- Updated the core Selecto lower bound to `0.4.8` for the shared bounded model
+  checker.
+
 V 0.4.8
 --------
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It is the package you use when you want users to:
 ```elixir
 def deps do
   [
-    {:selecto_components, ">= 0.4.8 and < 0.6.0"},
+    {:selecto_components, ">= 0.4.9 and < 0.6.0"},
     {:selecto, ">= 0.4.8 and < 0.6.0"},
     {:selecto_db_postgresql, ">= 0.4.4 and < 0.6.0"},
     {:selecto_mix, ">= 0.4.6 and < 0.6.0"}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is the package you use when you want users to:
 
 - Phoenix 1.7+
 - Elixir ~> 1.18
-- `selecto >= 0.4.6 and < 0.6.0`
+- `selecto >= 0.4.8 and < 0.6.0`
 - an adapter package such as `selecto_db_postgresql >= 0.4.4 and < 0.6.0`
 - `selecto_mix >= 0.4.6 and < 0.6.0` if you want generators and installation helpers
 
@@ -38,12 +38,19 @@ It is the package you use when you want users to:
 def deps do
   [
     {:selecto_components, ">= 0.4.8 and < 0.6.0"},
-    {:selecto, ">= 0.4.6 and < 0.6.0"},
+    {:selecto, ">= 0.4.8 and < 0.6.0"},
     {:selecto_db_postgresql, ">= 0.4.4 and < 0.6.0"},
     {:selecto_mix, ">= 0.4.6 and < 0.6.0"}
   ]
 end
 ```
+
+## Formal verification
+
+`mix selecto_components.verify --output PATH` exhaustively checks the built-in
+action-visibility model. It proves that target decisions and host capability
+policy combine monotonically: hidden outranks disabled, disabled outranks
+enabled, and stricter policy cannot reveal an action.
 
 Then run the recommended integration task:
 

--- a/lib/mix/tasks/selecto_components.verify.ex
+++ b/lib/mix/tasks/selecto_components.verify.ex
@@ -1,0 +1,41 @@
+defmodule Mix.Tasks.SelectoComponents.Verify do
+  use Mix.Task
+
+  @shortdoc "Runs SelectoComponents bounded formal verification"
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, rest, invalid} = OptionParser.parse(args, strict: [output: :string])
+
+    if rest != [] or invalid != [],
+      do: Mix.raise("usage: mix selecto_components.verify [--output PATH]")
+
+    reports = [SelectoComponents.Verification.ActionVisibility.verify()]
+
+    artifact = %{
+      format: "selecto.formal_verification_suite",
+      format_version: 1,
+      generated_at: DateTime.utc_now() |> DateTime.to_iso8601(),
+      proved?: Enum.all?(reports, & &1.proved?),
+      reports: reports
+    }
+
+    Enum.each(reports, fn report ->
+      status = if report.proved?, do: "PROVED", else: "FAILED"
+
+      Mix.shell().info(
+        "#{status} #{report.model}: #{report.check_count} checks (proof=#{report.proof_level})"
+      )
+    end)
+
+    if path = opts[:output], do: write(path, artifact)
+    unless artifact.proved?, do: Mix.raise("SelectoComponents verification found counterexamples")
+  end
+
+  defp write(path, artifact) do
+    path = Path.expand(path)
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode_to_iodata!(artifact, pretty: true))
+    Mix.shell().info("Wrote verification artifact to #{path}")
+  end
+end

--- a/lib/selecto_components/actions.ex
+++ b/lib/selecto_components/actions.ex
@@ -520,12 +520,18 @@ defmodule SelectoComponents.Actions do
   defp merge_resolver_decision(explicit_decision, resolver_decision) do
     explicit = normalize_decision(explicit_decision, "enabled")
     resolver = normalize_decision(resolver_decision, "enabled")
+    explicit_status = normalize_status(map_value(explicit, :status))
+    resolver_status = normalize_status(map_value(resolver, :status))
 
-    case normalize_status(map_value(resolver, :status)) do
-      "enabled" -> explicit
-      _status -> Map.merge(explicit, resolver)
-    end
+    if status_rank(explicit_status) >= status_rank(resolver_status),
+      do: explicit,
+      else: resolver
   end
+
+  defp status_rank("enabled"), do: 0
+  defp status_rank("disabled"), do: 1
+  defp status_rank("hidden"), do: 2
+  defp status_rank(_status), do: 1
 
   defp action_label(action) do
     map_value(action, :label) ||

--- a/lib/selecto_components/form/event_handlers/view_lifecycle.ex
+++ b/lib/selecto_components/form/event_handlers/view_lifecycle.ex
@@ -37,6 +37,7 @@ defmodule SelectoComponents.Form.EventHandlers.ViewLifecycle do
       ## Returns
       `{:noreply, socket}` with updated active_tab assign
       """
+      @impl true
       def handle_event("set_active_tab", params, socket) do
         {:noreply, SessionStore.assign_active_tab(socket, Map.get(params, "tab"))}
       end
@@ -315,6 +316,7 @@ defmodule SelectoComponents.Form.EventHandlers.ViewLifecycle do
 
       defp manual_change_from_saved_view?(_params, _socket), do: false
 
+      @impl true
       def handle_info({:copy_aggregate_to_graph, form_state_query}, socket) do
         with_error_handling(socket, "copy_aggregate_to_graph", fn ->
           {:noreply, apply_copy_aggregate_to_graph(socket, form_state_query)}

--- a/lib/selecto_components/verification/action_visibility.ex
+++ b/lib/selecto_components/verification/action_visibility.ex
@@ -1,0 +1,76 @@
+defmodule SelectoComponents.Verification.ActionVisibility do
+  @moduledoc """
+  Bounded verification of capability-driven action visibility.
+
+  It proves that combining target decisions with host policy always selects the
+  more restrictive status, so stricter policy cannot reveal an action.
+  """
+
+  alias Selecto.Verification.BoundedModel
+  alias SelectoComponents.Actions
+
+  @statuses [:enabled, :disabled, :hidden]
+
+  def verify do
+    states =
+      for explicit <- @statuses,
+          resolver <- @statuses do
+        %{
+          explicit: explicit,
+          resolver: resolver,
+          actions:
+            Actions.available(contract(),
+              decisions: %{"approve" => %{status: explicit}},
+              capability_resolver: fn _request -> decision(resolver) end
+            )
+        }
+      end
+
+    BoundedModel.check("selecto_components.action_visibility.v1", states, [
+      {"effective_status_is_most_restrictive", &most_restrictive/1},
+      {"hidden_actions_never_reappear", &hidden_never_reappears/1}
+    ])
+  end
+
+  defp most_restrictive(state) do
+    expected = Enum.max_by([state.explicit, state.resolver], &rank/1)
+
+    actual =
+      case state.actions do
+        [] -> :hidden
+        [action] -> String.to_existing_atom(action.status)
+      end
+
+    if actual == expected,
+      do: :ok,
+      else: {:error, %{expected: expected, actual: actual}}
+  end
+
+  defp hidden_never_reappears(%{explicit: :hidden, actions: []}), do: :ok
+  defp hidden_never_reappears(%{resolver: :hidden, actions: []}), do: :ok
+  defp hidden_never_reappears(%{explicit: :hidden} = state), do: {:error, state.actions}
+  defp hidden_never_reappears(%{resolver: :hidden} = state), do: {:error, state.actions}
+  defp hidden_never_reappears(_state), do: :ok
+
+  defp rank(:enabled), do: 0
+  defp rank(:disabled), do: 1
+  defp rank(:hidden), do: 2
+
+  defp decision(:enabled), do: Selecto.Capabilities.allow(:allowed)
+  defp decision(:disabled), do: Selecto.Capabilities.deny(:denied)
+  defp decision(:hidden), do: Selecto.Capabilities.hidden(:hidden)
+
+  defp contract do
+    %{
+      "actions" => [
+        %{
+          "id" => "approve",
+          "label" => "Approve",
+          "scope" => "row",
+          "capability" => "orders.approve",
+          "execution" => %{"operation" => "update"}
+        }
+      ]
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -66,7 +66,7 @@ defmodule SelectoComponents.MixProject do
     if use_local_selecto?() do
       {:selecto, path: "../selecto"}
     else
-      {:selecto, ">= 0.4.6 and < 0.6.0"}
+      {:selecto, ">= 0.4.8 and < 0.6.0"}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SelectoComponents.MixProject do
   def project do
     [
       app: :selecto_components,
-      version: "0.4.8",
+      version: "0.4.9",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       description:

--- a/test/selecto_components/actions_test.exs
+++ b/test/selecto_components/actions_test.exs
@@ -172,6 +172,16 @@ defmodule SelectoComponents.ActionsTest do
     assert action.reason == "Target is already closed"
   end
 
+  test "a resolver cannot reveal an explicitly hidden action" do
+    assert [] =
+             Actions.available(write_contract(),
+               decisions: %{"approve_order" => %{status: :hidden}},
+               capability_resolver: fn _request ->
+                 Selecto.Capabilities.deny(:role_denied)
+               end
+             )
+  end
+
   test "filters hidden actions and can scope visible actions" do
     contract =
       write_contract(%{

--- a/test/selecto_components/verification/action_visibility_test.exs
+++ b/test/selecto_components/verification/action_visibility_test.exs
@@ -1,0 +1,12 @@
+defmodule SelectoComponents.Verification.ActionVisibilityTest do
+  use ExUnit.Case, async: true
+
+  test "proves capability visibility monotonicity" do
+    report = SelectoComponents.Verification.ActionVisibility.verify()
+
+    assert report.state_count == 9
+    assert report.invariant_count == 2
+    assert report.check_count == 18
+    assert report.proved?, inspect(report.counterexamples, pretty: true)
+  end
+end


### PR DESCRIPTION
Bring upstream in sync with the current seeken/main package state.

Included commits:
- Release selecto_components 0.4.9
- Add action visibility verification
- Annotate injected LiveView callbacks

Validation already run locally:
- `SELECTO_ECOSYSTEM_USE_LOCAL=1 mise exec -- mix test` (828 passed)
- `SELECTO_ECOSYSTEM_USE_LOCAL=false mise exec -- mix hex.build`